### PR TITLE
ci: Migrate from GitLab CI to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+---
+# https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+orbs:
+  hugo: circleci/hugo@1.2.1
+
+workflows:
+  main:
+    jobs:
+      - hugo/build:
+          asciidoc: true
+          html-proofer: false
+          version: "latest"
+      - deploy:
+          filters:
+            branches:
+              only: main
+          requires:
+            - hugo/build
+
+jobs:
+  deploy:
+    docker:
+      - image: cibuilds/hugo:latest
+    working_directory: ~/hugo
+    environment:
+      HUGO_BUILD_DIR: ~/hugo/public
+    steps:
+      # install git and asciidoc
+      - run: apk update && apk add git asciidoc
+
+      # checkout the repository
+      - checkout
+
+      # install git submodules for managing third-party dependencies
+      - run: git submodule sync && git submodule update --init
+
+      # build with Hugo
+      - run: HUGO_ENV=production hugo -v -d $HUGO_BUILD_DIR
+
+      - deploy:
+          name: Deploy to GitHub Pages
+          command: ./.circleci/deploy.sh

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Force-push the built HTML to the `gh-pages` branch.
+#
+
+set -e
+
+DEPLOY_DIR=deploy
+
+git config --global push.default simple
+git config --global user.email $(git --no-pager show --no-patch --format='%ae' HEAD)
+git config --global user.name $CIRCLE_USERNAME
+
+git clone --quiet --branch=gh-pages $CIRCLE_REPOSITORY_URL $DEPLOY_DIR
+
+cd $DEPLOY_DIR
+rsync --archive --recursive --verbose --delete ../public/* .
+
+git add --force .
+git commit --msg="Deploy build $CIRCLE_BUILD_NUM [ci skip]" || true
+git push --force origin gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ hugo.exe
 hugo.darwin
 hugo.linux
 
+##### ---- htmlproofer ---- #####
+/tmp/
 
 
 ######################## ----- OPERATING SYSTEMS ----- ########################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,0 @@
----
-include:
-  - local: .gitlab/ci/yaml.gitlab-ci.yml
-  - local: .gitlab/ci/hugo.gitlab-ci.yml
-  - local: .gitlab/ci/pages.gitlab-ci.yml


### PR DESCRIPTION
This commit uses an existing GitHub Action to build and deploy a Hugo site to GitHub Pages. Let's see if it works.