### PR TITLE
ci: Use apt, not apk, in deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       HUGO_BUILD_DIR: ~/hugo/public
     steps:
       # install git and asciidoc
-      - run: apk update && apk add git asciidoc
+      - run: apt-get --yes update && apt-get install --yes git asciidoc
 
       # checkout the repository
       - checkout


### PR DESCRIPTION
The CI environment deploys from Ubuntu 18.04. I was using the Alpine
package manager, `apk`, but of course it is not installed. This should
fix this issue.

I have to merge this change to `main` to evaluate whether it will deploy
the site or not.