### PR TITLE
:wrench: switch social links to use unicef

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -107,11 +107,11 @@ contact_form_action = "#"
 
 [[params.social]]
 icon = "ti-github"
-link = "https://github.com/jwflory"
+link = "https://github.com/unicef/inventory"
 
 [[params.social]]
 icon = "ti-twitter"
-link = "https://twitter.com/jwf_foss"
+link = "https://twitter.com/UNICEFinnovate"
 
 
 ################################ English Language ######################


### PR DESCRIPTION
The social links were pointing towards @jwflory's social accounts This
change switches them to point toward's unicef's github and twitter