### PR TITLE
ci: Enable htmlproofer checks on new Pull Requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,17 @@
 version: 2.1
 
 orbs:
-  hugo: circleci/hugo@1.2.1
+  hugo: circleci/hugo@1.2.2
 
 workflows:
   main:
     jobs:
       - hugo/build:
           asciidoc: true
-          html-proofer: false
+          html-proofer: true
+          htmlproofer-http-status-ignore: "'0,999'"
+          htmlproofer-url-ignore: "'/inventory/'"
+          htmlproofer-timeframe: "'6w'"
           version: "latest"
       - deploy:
           filters:


### PR DESCRIPTION
Added in CircleCI-Public/hugo-orb#45 and CircleCI-Public/hugo-orb#46.

This commit turns HTML Proofer back on. Previously, it failed because of
unexpected error codes from sites linked elsewhere. This uses the new
feature flags added upstream in an effort to hopefully gain the helpful
feedback of when links in the site are broken.