### PR TITLE
meta: Initial commit, structure overview of O.S. Mentorship

### DIFF
--- a/content/meta/overview.en.adoc
+++ b/content/meta/overview.en.adoc
@@ -1,0 +1,92 @@
+---
+title: "Open Source Mentorship programme overview"
+weight: 1
+
+---
+// document settings
+:hide-uri-scheme:
+// reference links
+:unicef-advisor: Justin W. Flory
+:unicef-advisor-email: jflory [at] unicef [dot] org
+:unicef-fund: https://www.unicefinnovationfund.org/[UNICEF Innovation Fund,window=read-later]
+:unicef-colleague-support-timeframe: within 1-2 weeks
+
+This page documents and explains the general structure, approach, and methods of the Open Source Mentorship programme hosted on this website.
+The Open Source Mentorship programme is offered by the {unicef-fund}.
+See the table of contents for navigating.
+
+//TODO fix hugo theme to correctly render toc attributes instead of hand-typing them out
+. link:#team[Programme team]
+. link:#eligibility[Eligibility]
+.. link:#eligibility-fund[Innovation Fund grantees]
+.. link:#eligibility-unicef[UNICEF colleagues]
+.. link:#eligibility-others[Other groups]
+. link:#roadmap[12-month roadmap]
+. link:#roadmap-q1[Q1]
+. link:#roadmap-q2[Q2]
+. link:#roadmap-q3[Q3]
+. link:#roadmap-q4[Q4]
+
+
+[[team]]
+== Programme team
+
+The Open Source Mentorship programme is administered by the Innovation Fund _Open Source Technical Advisor_.
+Currently, this is {unicef-advisor} <{unicef-advisor-email}>.
+
+Any mentor who is an active 3-month or longer engagement may be listed here as well.
+
+
+[[eligibility]]
+== Eligibility
+
+The guided Open Source Mentorship programme is a 12-month incubator to help a small, agile team craft an Open Source strategy around a product.
+Eligibility for this hands-on, interactive mentorship is a closed invitation for the groups below:
+
+[[eligibility-fund]]
+=== Innovation Fund grantees
+
+*Innovation Fund grantees are eligible to enroll in the Open Source Mentorship programme for the duration of their workplans.*
+
+Innovation Fund grantees learn about the Open Source Mentorship programme in their on-boarding webinars with the Innovation Fund.
+Their assigned Open Source mentor will reach out with more information after on-boarding about enrollment.
+
+[[eligibility-unicef]]
+=== UNICEF colleagues
+
+*UNICEF colleagues around the world are eligible to enroll in appointments with Open Source mentors, with priority to Country Offices.*
+
+Anyone associated with UNICEF may request appointments for evaluation and assessment by Open Source mentors.
+These appointments are scheduled as there is availability.
+Current wait times for appointments are {unicef-colleague-support-timeframe}.
+
+Email the link:#team[programme team] from a UNICEF email address to schedule an appointment.
+
+[[eligibility-others]]
+=== Other groups
+
+*Other groups, including other UN agencies, NGOs, or community partners are not eligible for the Open Source Mentorship programme.*
+
+This limitation is to reduce risk and ensure capacity for meeting the needs of eligible groups.
+In the future, if additional capacity is added to the Open Source Mentorship programme, eligibility criteria will be reassessed.
+
+
+[[roadmap]]
+== 12-month roadmap
+
+This section is a work in progress.
+
+[[roadmap-q1]]
+=== Q1
+
+[[roadmap-q2]]
+=== Q2
+
+[[roadmap-q3]]
+=== Q3
+
+[[roadmap-q4]]
+=== Q4
+
+[[refs]]
+== References


### PR DESCRIPTION
This commit adds a first draft of the structure of the UNICEF Open
Source Mentorship programmed offered in the UNICEF Ventures team.
Eligibility is the only defined criteria of the document so far, but a
12-month roadmap of common milestones and achievements will be added in
future commits.