### PR TITLE
meta: Add four issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.md
+++ b/.github/ISSUE_TEMPLATE/01-bug.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: 'Notice something wrong? Open a bug report to help us investigate.'
+title: '[HUGO] '
+labels: bug, needs triage
+assignees: 'jwflory'
+
+---
+
+# Summary
+
+<!-- One sentence description of what the bug is. -->
+
+
+# Standard debugging steps
+
+## How to reproduce?
+
+<!-- For example:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**:
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Stacktrace
+
+<!-- If you have a stacktrace or log, paste it between the quoted lines below: -->
+
+```
+paste logs here
+```
+
+
+# Other details
+
+<!-- Add any other context about the problem here. If not, leave blank. -->

--- a/.github/ISSUE_TEMPLATE/02-improvement.md
+++ b/.github/ISSUE_TEMPLATE/02-improvement.md
@@ -1,0 +1,34 @@
+---
+name: Improvement to existing functionality
+about: 'Suggest an improvement to something that already exists.'
+title: '[HUGO] '
+labels: improvement, needs triage
+assignees: 'jwflory'
+
+---
+
+# Summary
+
+<!-- One sentence summary of how something can be better. -->
+
+
+# Background
+
+**Is your improvement related to a problem? Please describe**:
+<!-- A clear and concise description of what the problem is. Ex. I'm frustrated when [...] -->
+
+**Describe the solution you'd like**:
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**:
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
+# Details
+
+<!-- Details to understand how this task should be completed or carried out. What are the next steps? Add any other context or screenshots about the feature request here. -->
+
+
+# Outcome
+
+<!-- One sentence to describe what the end result will be once this ticket is complete. -->

--- a/.github/ISSUE_TEMPLATE/03-new.md
+++ b/.github/ISSUE_TEMPLATE/03-new.md
@@ -1,0 +1,34 @@
+---
+name: New feature request
+about: 'Have a creative new idea for something we haven't seen before? Bring it here.'
+title: '[HUGO] '
+labels: needs triage, new change
+assignees: 'jwflory'
+
+---
+
+# Summary
+
+<!-- One sentence summary of how something can be better. -->
+
+
+# Background
+
+**Is your feature request related to a problem? Please describe**:
+<!-- A clear and concise description of what the problem is. Ex. I'm frustrated when [...] -->
+
+**Describe the solution you'd like**:
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**:
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
+# Details
+
+<!-- Details to understand how this task should be completed or carried out. What are the next steps? Add any other context or screenshots about the feature request here. -->
+
+
+# Outcome
+
+<!-- One sentence to describe what the end result will be once this ticket is complete. -->

--- a/.github/ISSUE_TEMPLATE/04-content.md
+++ b/.github/ISSUE_TEMPLATE/04-content.md
@@ -1,0 +1,26 @@
+---
+name: Content improvements, suggestions, corrections
+about: 'Anything to do with the information published on the site itself should use this template. Unrelated to website UI/UX and features.'
+title: '[CONTENT] '
+labels: documentation, needs triage
+assignees: 'jwflory'
+
+---
+
+## Content classification
+
+_Is this about an existing page or a request for a new one?_
+
+<!-- Delete lines that are NOT RELATED. -->
+
+**Existing page**.
+The URL for the existing page is: <!-- delete this and write here -->"
+
+**Request for a new page, category, or section**.
+The title of the new content is: "<!-- delete this and write here -->"
+If a page, it will belong to this category: <!-- delete this and write here -->"
+
+
+## Content description
+
+<!-- Describe your improvement, suggestion, or correction here. -->


### PR DESCRIPTION
I added four new issue templates:

1. Bug reports
2. Improvements for existing functionality
3. New features and ideas
4. Content improvements, suggestions, and corrections

I realized there were not any issue templates, and this makes it hard
for me to structure my own thoughts when reviewing requirements for
upcoming work.