### PR TITLE
theme: Update git submodule to forked theme (closes #13)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "themes/dot"]
-	path = themes/dot
+[submodule "themes/inventory"]
+	path = themes/inventory
 	url = https://github.com/themefisher/dot.git

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 ################################# Default configuration ###################
 baseURL = "https://unicef.github.io/inventory/"
 title = "UNICEF O.S. Inventory"
-theme = "dot"
+theme = "inventory"
 enableEmoji = true
 enableGitInfo = true
 


### PR DESCRIPTION
This commit updates the UNICEF Open Source Inventory to use a new git
submodule for the Hugo theme. The new submodule comes from a forked
repository of the original Dot theme used in the project.

In the future clones and CI pipelines, it should use the new theme. This
allows us to test new changes made to the theme locally from this Hugo
site (without deploying a new version to production to test).

Closes #13.

CC: @Idadelveloper, this will un-block issue #14 so it can be worked on.