### PR TITLE
docs: Add @google MediaPipe documentation to Hall of Fame

### DIFF
--- a/content/documentation/hall-of-fame.en.adoc
+++ b/content/documentation/hall-of-fame.en.adoc
@@ -42,6 +42,9 @@ These examples show projects that offer clear and concise documentation for deve
 * *Medium to large projects*:
 ** https://docs.mongodb.com/manual/[MongoDB]
 ** https://laravel.com/docs/[Laravel]
+** https://google.github.io/mediapipe/[*Google MediaPipe*]:
+   MediaPipe offers cross-platform, customizable ML solutions for live and streaming media.
+   MediaPipe documentation clearly explains what MediaPipe is, its strongest benefits as a tool for developers, and helpful information to start using it.
 
 * *Large project*:
   https://jupyterlab.readthedocs.io/en/latest/developer/repo.html[JupyterLab]


### PR DESCRIPTION
This commit adds a new entry for the @google MediaPipe documentation
into the existing Documentation Hall of Fame:

https://google.github.io/mediapipe/

It was shared with me by current @unicef Innovation Fund grantee
@Wonder-Tree. Props to @musab1234 and @usmankaiz for sharing this one in
an Open Source Mentorship programme call.