### PR TITLE
git: Use updated submodule for forked repo theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/inventory"]
 	path = themes/inventory
-	url = https://github.com/themefisher/dot.git
+	url = https://github.com/unicef/inventory-hugo-theme.git


### PR DESCRIPTION
Somehow I forgot to update the submodule URL in PR #16, even though I
changed the other submodule metadata. Sometimes this stuff can be weird.

Props to @Idadelveloper for pointing this one out.