### PR TITLE
content: Add OpenGraph description & tags to articles (closes #18)

### DIFF
--- a/content/communities/fedora.en.adoc
+++ b/content/communities/fedora.en.adoc
@@ -1,6 +1,8 @@
 ---
-title: "Fedora"
+title: Fedora Project
 weight: 50
+description: The Fedora Project is a community of people working together to build a free and open source operating system.
+tags: ["linux"]
 
 ---
 :toc:

--- a/content/communities/public-lab.en.adoc
+++ b/content/communities/public-lab.en.adoc
@@ -1,6 +1,8 @@
 ---
-title: "Public Lab"
+title: Public Lab
 weight: 100
+description: Public Lab is a community and a non-profit, democratizing science to address environmental issues that affect people.
+tags: ["citizen science", "environment"]
 
 ---
 

--- a/content/data/milestone-roadmap.en.adoc
+++ b/content/data/milestone-roadmap.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "AI Ethics & Transparency Roadmap - Template"
 weight: 10
+description: How do you document your machine learning development process? This guide shares transparency best practices.
+tags: ["template"]
 
 ---
 

--- a/content/data/model-card.en.adoc
+++ b/content/data/model-card.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Machine Learning Model Card"
 weight: 20
+description: Model cards help you document how your model was made. Use this overview to make your own model cards.
+tags: ["design", "template"]
 
 ---
 

--- a/content/data/traps.en.adoc
+++ b/content/data/traps.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Common traps to avoid when building AI systems"
 weight: 30
+description: Assessing common AI/ML mistakes that lead to unintended side effects.
+tags: ["design"]
 
 ---
 _Assessing common mistakes that lead to unintended side effects._

--- a/content/design/reading-list.en.adoc
+++ b/content/design/reading-list.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Design & UX Reading List"
 weight: 10
+description: Various readings and learnings about design in an Open Source context.
+tags: ["reading list"]
 
 ---
 

--- a/content/dev-tools/continuous-integration.md
+++ b/content/dev-tools/continuous-integration.md
@@ -1,10 +1,12 @@
 ---
 title: "Continuous Integration (CI)"
 weight: 10
+description: An introduction to creating a Continuous Integration (CI) pipeline for an Open Source project.
+tags: ["testing"]
 
 ---
 
-This guide is an introduction to Continuous Integration (C.I.) for open source projects.
+This guide is an introduction to Continuous Integration (C.I.) for Open Source projects.
 In this guide, you will learn about the following topics:
 
 1. What is CI and why does it matter?

--- a/content/documentation/frontier-tech-tips.en.adoc
+++ b/content/documentation/frontier-tech-tips.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Frontier technology tips"
 weight: 10
+description: A summary of Andrew Burden's DevConf 2020 talk about best practices for documenting emerging technology.
+tags: ["innovation"]
 
 ---
 

--- a/content/documentation/hall-of-fame.en.adoc
+++ b/content/documentation/hall-of-fame.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: Documentation Hall of Fame
 weight: 20
+description: Real examples of Open Source projects with excellent documentation.
+tags: ["hall of fame"]
 
 ---
 :toc:

--- a/content/documentation/reading-list.en.adoc
+++ b/content/documentation/reading-list.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Reading list"
 weight: 30
+description: Various readings and learnings about documentation in an Open Source context.
+tags: ["reading list"]
 
 ---
 

--- a/content/documentation/text-editors.en.adoc
+++ b/content/documentation/text-editors.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Text editors"
 weight: 50
+description: Educational resources, guides, and information about text editors and IDEs.
+tags: ["tools"]
 
 ---
 

--- a/content/foss/business-sustainability.adoc
+++ b/content/foss/business-sustainability.adoc
@@ -1,6 +1,8 @@
 ---
 title: Business sustainability for Open Source
 weight: 10
+description: Information, best practices, and resources about Open Source business sustainability and business models.
+tags: ["sustainability"]
 
 ---
 :toc:

--- a/content/foss/contributor-license-agreement-cla.en.md
+++ b/content/foss/contributor-license-agreement-cla.en.md
@@ -1,6 +1,8 @@
 ---
 title: "Contributor License Agreements (CLAs)"
 weight: 20
+description: When does your Open Source project need a CLA? What alternatives exist? Cover your copyright in this intro to CLAs.
+tags: ["legal"]
 
 ---
 

--- a/content/foss/governance.adoc
+++ b/content/foss/governance.adoc
@@ -1,6 +1,8 @@
 ---
 title: Governance
 weight: 25
+description: Best practices and examples of governance in real Open Source projects.
+tags: ["policy"]
 
 ---
 

--- a/content/foss/gpl-comparison.en.adoc
+++ b/content/foss/gpl-comparison.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "GPLv2 vs. GPLv3"
 weight: 30
+description: A deep dive on the exact differences between the Free Software Foundation's two versions of the GPL license.
+tags: ["legal"]
 
 ---
 *The information shared on this page does not constitute legal or financial advice*.

--- a/content/foss/reading-list-foss.en.adoc
+++ b/content/foss/reading-list-foss.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Reading list: FOSS"
 weight: 50
+description: Various readings and learnings about Free and Open Source Software.
+tags: ["reading list"]
 
 ---
 :toc:

--- a/content/foss/reading-list-legal.en.adoc
+++ b/content/foss/reading-list-legal.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Reading List: Legal & Business Aspects"
 weight: 60
+description: Various readings and learnings about business and legal aspects of Open Source intellectual property.
+tags: ["reading list"]
 
 ---
 :toc:

--- a/content/foss/reading-list-outreach.en.adoc
+++ b/content/foss/reading-list-outreach.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Outreach reading list"
 weight: 70
+description: Various readings and learnings about outreach and marketing in an Open Source context.
+tags: ["reading list"]
 
 ---
 

--- a/content/hardware/case-studies.md
+++ b/content/hardware/case-studies.md
@@ -1,6 +1,8 @@
 ---
 title: Case studies
 weight: 10
+description: Detailed case studies and analysis of different Open Hardware organizations, projects, and products.
+tags: ["hall of fame"]
 
 ---
 

--- a/content/hardware/documentation.md
+++ b/content/hardware/documentation.md
@@ -1,6 +1,8 @@
 ---
 title: Documentation
 weight: 20
+description: How does documentation work for Open Source Hardware? This page provides a brief introduction.
+tags: ["reading list"]
 
 ---
 

--- a/content/hardware/intro.en.adoc
+++ b/content/hardware/intro.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: Introduction to Open Source Hardware
 weight: 1
+description: So, you want to know about Open Source Hardware? Start here to get an introduction to the landscape in the 2020s.
+tags: ["philosophy"]
 
 ---
 :definition: https://www.oshwa.org/definition/

--- a/content/hardware/licensing.md
+++ b/content/hardware/licensing.md
@@ -1,6 +1,8 @@
 ---
 title: Licensing
 weight: 30
+description: Information, resources, and details about common licenses used for Open Source Hardware projects.
+tags: ["legal"]
 
 ---
 

--- a/content/hardware/projects.md
+++ b/content/hardware/projects.md
@@ -1,6 +1,8 @@
 ---
 title: Project Hall of Fame
 weight: 50
+description: Various Open Source Hardware projects and links back to their projects and/or communities.
+tags: ["hall of fame"]
 
 ---
 

--- a/content/hardware/reading-list.md
+++ b/content/hardware/reading-list.md
@@ -1,6 +1,8 @@
 ---
 title: "Open Hardware reading list"
 weight: 40
+description: Various readings and learnings about Open Source Hardware that do not belong on another page.
+tags: ["reading list"]
 
 ---
 

--- a/content/meta/modules.en.adoc
+++ b/content/meta/modules.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Modules"
 weight: 10
+description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
+tags: ["docs", "legal", "testing"]
 
 ---
 // document settings

--- a/content/meta/needs-assessment-template.en.adoc
+++ b/content/meta/needs-assessment-template.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Needs assessment interview template"
 weight: 50
+description: Interview template for UNICEF mentors when meeting a team for the first time.
+tags: ["tools"]
 
 ---
 

--- a/content/meta/overview.en.adoc
+++ b/content/meta/overview.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Open Source Mentorship programme overview"
 weight: 1
+description: An introduction to the UNICEF Open Source Mentorship programme. Hosted by the Office of Innovation.
+tags: []
 
 ---
 // document settings

--- a/content/meta/templates.en.adoc
+++ b/content/meta/templates.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Templates for programme mentors"
 weight: 60
+description: Various templates and reusable copytext for UNICEF Open Source Mentorship programme mentors.
+tags: ["tools"]
 
 ---
 :toc:

--- a/content/missions/codes-of-conduct.en.md
+++ b/content/missions/codes-of-conduct.en.md
@@ -1,6 +1,8 @@
 ---
 title: "Codes of Conduct"
 weight: 10
+description: Embark on a mission to add a Code of Conduct to your Open Source community.
+tags: ["community"]
 
 ---
 

--- a/content/missions/good-first-issue.en.adoc
+++ b/content/missions/good-first-issue.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Good first issues"
 weight: 20
+description: Embark on a mission to enable new contributors to your Open Source project with Good First Issues (GFIs).
+tags: ["community"]
 
 ---
 

--- a/content/project-management/issue-templates.en.adoc
+++ b/content/project-management/issue-templates.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Issue templates"
 weight: 10
+description: An introduction to issue templates for new Open Source project or community managers.
+tags: ["community"]
 
 ---
 

--- a/content/project-management/project-boards.en.md
+++ b/content/project-management/project-boards.en.md
@@ -1,6 +1,8 @@
 ---
 title: "Project boards"
 weight: 20
+description: An introduction to project/kanban boards for new Open Source project or community managers.
+tags: ["community"]
 
 ---
 

--- a/content/project-management/reading-list.en.adoc
+++ b/content/project-management/reading-list.en.adoc
@@ -1,6 +1,8 @@
 ---
 title: "Community Management Reading List"
 weight: 30
+description: Various readings and learnings about community management in an Open Source context.
+tags: ["reading list"]
 
 ---
 

--- a/content/reproducibility/reading-list.md
+++ b/content/reproducibility/reading-list.md
@@ -1,7 +1,8 @@
 ---
 title: "Reproducibility reading list"
-type: "post"
 weight: 10
+description: Various readings and learnings about reproducibility in an Open Source context.
+tags: ["reading list"]
 
 ---
 


### PR DESCRIPTION
Per the new social media and OpenGraph features used in the upstream
Hugo theme, we can now display this kind of metadata alongside an
article. Since I am an avid fan of accurate metadata, I added these
fields to all existing articles for more interactive re-sharing.

Closes #18. Made possible in coordination with @MuluhGodson.