### PR TITLE
PR for #12 Highlight related articles at the bottom of each article.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,6 +116,9 @@ font_family = "Open+Sans"
 # contact form action (works with https://formspree.io)
 contact_form_action = "#"
 
+# related article number limit
+article_count = 3
+
 
 ############################# Social links #############################
 # themify icon pack : https://themify.me/themify-icons
@@ -145,6 +148,11 @@ lineNumbersInTable = true
 noClasses = true
 style = 'murphy'
 tabWidth = 4
+
+############################# Related Articles #############################
+[taxonomies]
+  category = "categories"
+
 
 #######################################################################################
 #                             Multilingual configurations                             #

--- a/content/communities/fedora.en.adoc
+++ b/content/communities/fedora.en.adoc
@@ -3,6 +3,7 @@ title: Fedora Project
 weight: 50
 description: The Fedora Project is a community of people working together to build a free and open source operating system.
 tags: ["linux"]
+categories: "communities"
 
 ---
 :toc:

--- a/content/communities/public-lab.en.adoc
+++ b/content/communities/public-lab.en.adoc
@@ -3,6 +3,7 @@ title: Public Lab
 weight: 100
 description: Public Lab is a community and a non-profit, democratizing science to address environmental issues that affect people.
 tags: ["citizen science", "environment"]
+categories: "communities"
 
 ---
 

--- a/content/data/milestone-roadmap.en.adoc
+++ b/content/data/milestone-roadmap.en.adoc
@@ -3,6 +3,7 @@ title: "AI Ethics & Transparency Roadmap - Template"
 weight: 10
 description: How do you document your machine learning development process? This guide shares transparency best practices.
 tags: ["template"]
+categories: "data"
 
 ---
 

--- a/content/data/model-card.en.adoc
+++ b/content/data/model-card.en.adoc
@@ -3,6 +3,7 @@ title: "Machine Learning Model Card"
 weight: 20
 description: Model cards help you document how your model was made. Use this overview to make your own model cards.
 tags: ["design", "template"]
+categories: "data"
 
 ---
 

--- a/content/data/traps.en.adoc
+++ b/content/data/traps.en.adoc
@@ -3,6 +3,7 @@ title: "Common traps to avoid when building AI systems"
 weight: 30
 description: Assessing common AI/ML mistakes that lead to unintended side effects.
 tags: ["design"]
+categories: "data"
 
 ---
 _Assessing common mistakes that lead to unintended side effects._

--- a/content/design/reading-list.en.adoc
+++ b/content/design/reading-list.en.adoc
@@ -3,6 +3,7 @@ title: "Design & UX Reading List"
 weight: 10
 description: Various readings and learnings about design in an Open Source context.
 tags: ["reading list"]
+categories: "design"
 
 ---
 

--- a/content/dev-tools/continuous-integration.en.adoc
+++ b/content/dev-tools/continuous-integration.en.adoc
@@ -3,6 +3,7 @@ title: "Continuous Integration (CI)"
 weight: 10
 description: An introduction to creating a Continuous Integration (CI) pipeline for an Open Source project.
 tags: ["testing"]
+categories: "dev-tools"
 
 ---
 

--- a/content/documentation/frontier-tech-tips.en.adoc
+++ b/content/documentation/frontier-tech-tips.en.adoc
@@ -3,6 +3,7 @@ title: "Frontier technology tips"
 weight: 10
 description: A summary of Andrew Burden's DevConf 2020 talk about best practices for documenting emerging technology.
 tags: ["innovation"]
+categories: "documentation"
 
 ---
 

--- a/content/documentation/hall-of-fame.en.adoc
+++ b/content/documentation/hall-of-fame.en.adoc
@@ -3,6 +3,7 @@ title: Documentation Hall of Fame
 weight: 20
 description: Real examples of Open Source projects with excellent documentation.
 tags: ["hall of fame"]
+categories: "documentation"
 
 ---
 :toc:

--- a/content/documentation/reading-list.en.adoc
+++ b/content/documentation/reading-list.en.adoc
@@ -3,6 +3,7 @@ title: "Reading list"
 weight: 30
 description: Various readings and learnings about documentation in an Open Source context.
 tags: ["reading list"]
+categories: "documentation"
 
 ---
 

--- a/content/documentation/text-editors.en.adoc
+++ b/content/documentation/text-editors.en.adoc
@@ -3,6 +3,7 @@ title: "Text editors"
 weight: 50
 description: Educational resources, guides, and information about text editors and IDEs.
 tags: ["tools"]
+categories: "documentation"
 
 ---
 

--- a/content/foss/_index.en.adoc
+++ b/content/foss/_index.en.adoc
@@ -3,5 +3,6 @@ title: "Free & Open Source Software"
 icon: "ti-world"
 description: "Build a better understanding of free and open source software."
 type: "docs"
+categories: "foss"
 
 ---

--- a/content/foss/business-sustainability.adoc
+++ b/content/foss/business-sustainability.adoc
@@ -3,6 +3,7 @@ title: Business sustainability for Open Source
 weight: 10
 description: Information, best practices, and resources about Open Source business sustainability and business models.
 tags: ["sustainability"]
+categories: "foss"
 
 ---
 :toc:

--- a/content/foss/contributor-license-agreement-cla.en.adoc
+++ b/content/foss/contributor-license-agreement-cla.en.adoc
@@ -3,6 +3,7 @@ title: "Contributor License Agreements (CLAs)"
 weight: 20
 description: When does your Open Source project need a CLA? What alternatives exist? Cover your copyright in this intro to CLAs.
 tags: ["legal"]
+categories: "foss"
 
 ---
 :toc:

--- a/content/foss/governance.adoc
+++ b/content/foss/governance.adoc
@@ -3,6 +3,7 @@ title: Governance
 weight: 25
 description: Best practices and examples of governance in real Open Source projects.
 tags: ["policy"]
+categories: "foss"
 
 ---
 

--- a/content/foss/gpl-comparison.en.adoc
+++ b/content/foss/gpl-comparison.en.adoc
@@ -3,6 +3,7 @@ title: "GPLv2 vs. GPLv3"
 weight: 30
 description: A deep dive on the exact differences between the Free Software Foundation's two versions of the GPL license.
 tags: ["legal"]
+categories: "foss"
 
 ---
 *The information shared on this page does not constitute legal or financial advice*.

--- a/content/foss/reading-list-foss.en.adoc
+++ b/content/foss/reading-list-foss.en.adoc
@@ -3,6 +3,7 @@ title: "Reading list: FOSS"
 weight: 50
 description: Various readings and learnings about Free and Open Source Software.
 tags: ["reading list"]
+categories: "foss"
 
 ---
 :toc:

--- a/content/foss/reading-list-legal.en.adoc
+++ b/content/foss/reading-list-legal.en.adoc
@@ -3,6 +3,7 @@ title: "Reading List: Legal & Business Aspects"
 weight: 60
 description: Various readings and learnings about business and legal aspects of Open Source intellectual property.
 tags: ["reading list"]
+categories: "foss"
 
 ---
 :toc:

--- a/content/foss/reading-list-outreach.en.adoc
+++ b/content/foss/reading-list-outreach.en.adoc
@@ -3,6 +3,7 @@ title: "Outreach reading list"
 weight: 70
 description: Various readings and learnings about outreach and marketing in an Open Source context.
 tags: ["reading list"]
+categories: "foss"
 
 ---
 

--- a/content/hardware/case-studies.en.adoc
+++ b/content/hardware/case-studies.en.adoc
@@ -3,6 +3,7 @@ title: Case studies
 weight: 10
 description: Detailed case studies and analysis of different Open Hardware organizations, projects, and products.
 tags: ["hall of fame"]
+categories: "hardware"
 
 ---
 :toc:

--- a/content/hardware/documentation.en.adoc
+++ b/content/hardware/documentation.en.adoc
@@ -3,6 +3,7 @@ title: Documentation
 weight: 20
 description: How does documentation work for Open Source Hardware? This page provides a brief introduction.
 tags: ["reading list"]
+categories: "hardware"
 
 ---
 

--- a/content/hardware/intro.en.adoc
+++ b/content/hardware/intro.en.adoc
@@ -3,6 +3,7 @@ title: Introduction to Open Source Hardware
 weight: 1
 description: So, you want to know about Open Source Hardware? Start here to get an introduction to the landscape in the 2020s.
 tags: ["philosophy"]
+categories: "hardware"
 
 ---
 :definition: https://www.oshwa.org/definition/

--- a/content/hardware/licensing.en.adoc
+++ b/content/hardware/licensing.en.adoc
@@ -3,6 +3,7 @@ title: Licensing
 weight: 30
 description: Information, resources, and details about common licenses used for Open Source Hardware projects.
 tags: ["legal"]
+categories: "hardware"
 
 ---
 :toc:

--- a/content/hardware/projects.en.adoc
+++ b/content/hardware/projects.en.adoc
@@ -3,6 +3,7 @@ title: Project Hall of Fame
 weight: 50
 description: Various Open Source Hardware projects and links back to their projects and/or communities.
 tags: ["hall of fame"]
+categories: "hardware"
 
 ---
 

--- a/content/hardware/reading-list.en.adoc
+++ b/content/hardware/reading-list.en.adoc
@@ -3,6 +3,7 @@ title: "Open Hardware reading list"
 weight: 40
 description: Various readings and learnings about Open Source Hardware that do not belong on another page.
 tags: ["reading list"]
+categories: "hardware"
 
 ---
 

--- a/content/meta/modules.en.adoc
+++ b/content/meta/modules.en.adoc
@@ -3,6 +3,7 @@ title: "Modules"
 weight: 10
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "legal", "testing"]
+categories: "meta"
 
 ---
 // document settings

--- a/content/meta/needs-assessment-template.en.adoc
+++ b/content/meta/needs-assessment-template.en.adoc
@@ -3,6 +3,7 @@ title: "Needs assessment interview template"
 weight: 50
 description: Interview template for UNICEF mentors when meeting a team for the first time.
 tags: ["tools"]
+categories: "meta"
 
 ---
 

--- a/content/meta/overview.en.adoc
+++ b/content/meta/overview.en.adoc
@@ -3,6 +3,7 @@ title: "Open Source Mentorship programme overview"
 weight: 1
 description: An introduction to the UNICEF Open Source Mentorship programme. Hosted by the Office of Innovation.
 tags: []
+categories: "meta"
 
 ---
 // document settings

--- a/content/meta/templates.en.adoc
+++ b/content/meta/templates.en.adoc
@@ -3,6 +3,7 @@ title: "Templates for programme mentors"
 weight: 60
 description: Various templates and reusable copytext for UNICEF Open Source Mentorship programme mentors.
 tags: ["tools"]
+categories: "meta"
 
 ---
 :toc:

--- a/content/meta/workflow-metrics.en.adoc
+++ b/content/meta/workflow-metrics.en.adoc
@@ -3,6 +3,7 @@ title: "Workflow: Update external UNICEF metrics"
 weight: 70
 description: How a UNICEF contractor manages and updates metrics about Innovation Fund portfolio company projects.
 tags: ["workflows"]
+categories: "meta"
 
 ---
 

--- a/content/meta/workplan-bridge-funding.en.adoc
+++ b/content/meta/workplan-bridge-funding.en.adoc
@@ -3,6 +3,7 @@ title: "Workplan: Bridge Fund cohort"
 weight: 80
 description: Open Source workplan requirements for UNICEF Open Source Mentorship programme. These requirements apply to companies in the Bridge Fund cohort.
 tags: []
+categories: "meta"
 
 ---
 // document settings

--- a/content/missions/codes-of-conduct.en.adoc
+++ b/content/missions/codes-of-conduct.en.adoc
@@ -3,6 +3,7 @@ title: "Codes of Conduct"
 weight: 10
 description: Embark on a mission to add a Code of Conduct to your Open Source community.
 tags: ["community"]
+categories: "missions"
 
 ---
 :page-authors: Justin W. Flory

--- a/content/missions/good-first-issue.en.adoc
+++ b/content/missions/good-first-issue.en.adoc
@@ -3,6 +3,7 @@ title: "Good first issues"
 weight: 20
 description: Embark on a mission to enable new contributors to your Open Source project with Good First Issues (GFIs).
 tags: ["community"]
+categories: "missions"
 
 ---
 

--- a/content/project-management/issue-templates.en.adoc
+++ b/content/project-management/issue-templates.en.adoc
@@ -3,6 +3,7 @@ title: "Issue templates"
 weight: 10
 description: An introduction to issue templates for new Open Source project or community managers.
 tags: ["community"]
+categories: "project-management"
 
 ---
 

--- a/content/project-management/project-boards.en.adoc
+++ b/content/project-management/project-boards.en.adoc
@@ -3,6 +3,7 @@ title: "Project boards"
 weight: 20
 description: An introduction to project/kanban boards for new Open Source project or community managers.
 tags: ["community"]
+categories: "project-management"
 
 ---
 

--- a/content/project-management/reading-list.en.adoc
+++ b/content/project-management/reading-list.en.adoc
@@ -3,6 +3,7 @@ title: "Community Management Reading List"
 weight: 30
 description: Various readings and learnings about community management in an Open Source context.
 tags: ["reading list"]
+categories: "project-management"
 
 ---
 

--- a/content/reproducibility/_index.en.adoc
+++ b/content/reproducibility/_index.en.adoc
@@ -3,5 +3,6 @@ title: "Reproducibility"
 icon: "ti-loop"
 description: "Building and developing reproducible code, science, and data."
 type: "docs"
+categories: "reproducibility"
 
 ---

--- a/content/reproducibility/reading-list.en.adoc
+++ b/content/reproducibility/reading-list.en.adoc
@@ -3,6 +3,7 @@ title: "Reproducibility reading list"
 weight: 10
 description: Various readings and learnings about reproducibility in an Open Source context.
 tags: ["reading list"]
+categories: "reproducibility"
 
 ---
 


### PR DESCRIPTION
From your previous comment, I optimized the code in a way that gives you the flexibility to determining what relates the articles. This is done in the front matter via the categories variable. articles in the same category will be related. Also if an image is specified in the Front matter of the article, this image will be used on the card when displaying the article as related to another, else it will just display a title and a description. I noticed each article now has a description (due to the OpenGraph PR).

In the config.toml under the general parameters, I added a new variable `article_count` which determines the maximum number of articles to be displayed in the related section. Currently, this value is set to 3 so at most 3 articles will be displayed. The current article being read is excluded from being displayed as related to itself. 