### PR TITLE
meta: Document workflow for capturing analytic data

### DIFF
--- a/content/meta/workflow-metrics.en.adoc
+++ b/content/meta/workflow-metrics.en.adoc
@@ -1,0 +1,22 @@
+---
+title: "Workflow: Update external UNICEF metrics"
+weight: 70
+description: How a UNICEF contractor manages and updates metrics about Innovation Fund portfolio company projects.
+tags: ["workflows"]
+
+---
+
+Open Source data and analytics are used across multiple tools and documents for talking about Innovation Fund portfolio companies.
+When updating data sources in official UNICEF portals, follow this process for the quickest way of updating metrics.
+
+. Open data input source (e.g. Sharepoint doc, Google Doc shared with company, etc.)
+. Open Cauldron.io dashboard for company/project
+. Look at annual ranges first before doing quarterly ranges.
+  Some metrics need to be collected manually for annual ranges:
+.. # of code contributors
+.. # of issue authors
+.. # of pull request submitters
+.. # of open/unresolved issues
+.. # of open/unresolved pull requests
+. Update Cauldron ranges as needed for each quarter.
+. Log metrics into data input source from Cauldron.


### PR DESCRIPTION
This commit adds a first publication of a new type of meta page to
document the process of how I generally collect metrics. It is very
rough, but the idea is this is something that can be built on and
expanded over time.