### PR TITLE
Add O.S. Inventory maintainer's guide (part of #30)

### DIFF
--- a/content/meta/maintainers-guide.en.adoc
+++ b/content/meta/maintainers-guide.en.adoc
@@ -1,0 +1,161 @@
+---
+title: "Maintainer's guide for O.S. Inventory"
+weight: 10
+description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
+tags: ["docs", "testing"]
+
+---
+// document settings
+:toc:
+:hide-uri-scheme:
+
+This document is a maintainer's guide for the UNICEF Open Source Inventory.
+Yes, this very site!
+This guide covers key information and helpful resources, as well as best practices when maintaining the O.S. Inventory.
+
+
+[[conventions]]
+== Contribution conventions
+
+This section explains contribution conventions for the Open Source Inventory.
+These are common conventions that all contributors are asked to make when contributing to this repository.
+Please make a best effort to follow these conventions at all times, unless there is a justified reason to break convention.
+
+[[conventions-labels]]
+=== Label conventions
+
+All issue and pull request labels belong to one of the meta-categories of labels below:
+
+. *_C_omponent*:
+  Used for indicating what component, or part, of the applications is related.
+  In a large project, there are different kinds of components that exist together in a repository.
+  The UNICEF Open Source Inventory includes content management, front-end code, and back-end code.
+  Usually indicates what kind of maintainer is needed to move forward.
+. *_I_nclusion*:
+  Used for community inclusion topics.
+  Issues or pull requests tagged with inclusion labels typically impact the contribution workflow and other people working on the project.
+. *_T_ype*:
+  What types of issues and pull requests do we get?
+  These labels indicate whether something _new_ is added or if improvements are made to existing components.
+. *_X_*:
+  Used for close statuses.
+  These labels are only used on closed issues and pull requests.
+. *_?_*:
+  Used for labels that require more information.
+  Usually indicates experienced maintainer action is required to move forward.
+
+[[conventions-commits]]
+=== Commit message conventions
+
+. *Prefix your commit message with the component you are changing, and optionally, an emoji*.
+  If you are editing a page in the _Project Management_ category, start your commit message with `Project Management:`.
+  If you are changing Hugo configurations, archetypes, or other tweaks, start your commit with message with `hugo:`.
+  And so on.
+  Optionally, you may add a https://gist.github.com/ricealexander/ae8b8cddc3939d6ba212f953701f53e6[GitHub emoji] to your commit message summary line that best represents your change.
+. *All commit messages on the `main` branch should be https://medium.com/compass-true-north/writing-good-commit-messages-fc33af9d6321[good commit messages]*.
+. *Avoid merge commits*.
+  Preserve good commit messages by rebase merging, or if commit messages are not helpful in aggregate, use squash merging.
+  Do not allow merge commits.
+
+[[conventions-submodule]]
+=== How to update git submodule as a maintainer
+
+There are two components to this Hugo website:
+*content repository* (https://github.com/unicef/inventory[unicef/inventory]) and *theme repository* (https://github.com/unicef/inventory-hugo-theme[unicef/inventory-hugo-theme]).
+
+The content repository hosts all of the written information published in the O.S. Inventory.
+The theme repository hosts the front-end design and Hugo templates used in the O.S. Inventory.
+The content repository clones the theme repository as a *git submodule* to the `themes/inventory/` path.
+Therefore, whenever changes are made to the upstream theme repository, the git submodule for the theme repository needs to be updated.
+The git submodule must be updated from the content repository.
+
+[[conventions-submodule-example]]
+==== Example: git in command line
+
+The shell commands below were tested with the git command line client, version 2.31 or later:
+
+[source,sh]
+----
+git submodule update --remote --rebase
+cd themes/inventory/
+git fetch
+git checkout <latest commit hash>
+cd ../../
+git add themes/inventory
+git commit --signoff
+----
+
+[[conventions-priorities]]
+=== How development decisions are prioritized
+
+Development decisions are prioritized according to the needs of the following stakeholders:
+
+. UNICEF Office of Innovation staff and consultants
+. UNICEF Innovation Fund grantees and portfolio companies
+. UNICEF colleagues
+. UN colleagues
+. Open Source practitioners and subject-matter experts (e.g. associated to a private-sector Open Source Program Office)
+. General public
+
+For as long as this list does not generate conflict, this is sufficient to guide development decisions by meeting the needs of key stakeholders.
+Over time, if this list creates friction, this part of the maintainer's guide should be revisited.
+
+
+[[resources]]
+== Common resources and cheat sheets
+
+This section provides common resources, links, and references for different subject material covered in the project.
+See the sub-headings below for quick references on any aspect of the UNICEF Open Source Inventory.
+
+[[resources-asciidoc]]
+=== AsciiDoc syntax cheat sheet
+
+[quote,asciidoctor.org]
+____
+AsciiDoc is a lightweight markup language for authoring notes, articles, documentation, books, web pages, slide decks and man pages in plain text.
+____
+
+https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[*AsciiDoc Syntax Quick Reference*]::
+Handy cheat sheet of what the AsciiDoc markup looks like.
+Use this for quick references and checking up on how to formatting, lists, media content (images and video), table of contents, and more.
+
+https://asciidoctor.org/docs/asciidoc-recommended-practices/[*AsciiDoc Recommended Practices*]::
+Best practices about writing in AsciiDoc.
+Most importantly, note that https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line[every sentence should be on its own line].
+
+[[resources-hugo]]
+=== Hugo documentation
+
+https://gohugo.io/documentation/[*Hugo Documentation*]::
+Main landing page for upstream Hugo documentation.
+This is the first resource to check when exploring more advanced feature development and changes to the site theme.
+
+https://discourse.gohugo.io/[*Hugo Community*]::
+Discussion and Q&A forum for upstream Hugo community.
+Good place to take questions, queries, and doubts about working with Hugo.
+
+https://github.com/gohugoio/hugo[*GitHub*]::
+Upstream GitHub repository for Hugo.
+Issue tracker is usually responsive.
+If you hit a bug or something seems wrong, open an issue and seek help from a maintainer *after you did your own homework*.
+
+[[resources-hugo-reading]]
+==== Suggested reading
+
+Not sure where to start?
+These pages are helpful primers:
+
+* https://gohugo.io/content-management/archetypes/[*Archetypes*]:
+  Archetypes are templates used when creating new content.
+* https://gohugo.io/content-management/front-matter/[*Front Matter*]:
+  Hugo allows you to add front matter in yaml, toml, or json to your content files.
+* https://gohugo.io/templates/[*Templates*]:
+  Overview of Hugo templating system.
+* https://gohugo.io/functions/[*Functions*]:
+  Overview of Go and Hugo functions.
+* https://gohugo.io/variables/[*Variables and Params*]:
+  Hugo templates are context-aware and make a large number of values available as you create views for your website.
+
+[[resources-ci]]
+=== CI pipeline (diagram)
+


### PR DESCRIPTION
This commit is a first attempt at creating a maintainer's guide for the
UNICEF Open Source Inventory. The document defines project conventions
as well as provides resources to learn more about the stack used in the
Inventory project.

This contributes to issue #30 but does not close it. This page is still
missing a diagram/chart of the Continuous Integration pipeline, and how
new updates are deployed from GitHub to the World Wide Web. Once the
chart is added, #30 may be closed as complete.