### PR TITLE
meta: Add Bridge Funding cohort workplan notes

### DIFF
--- a/content/meta/workplan-bridge-funding.en.adoc
+++ b/content/meta/workplan-bridge-funding.en.adoc
@@ -1,0 +1,215 @@
+---
+title: "Workplan: Bridge Fund cohort"
+weight: 80
+description: Open Source workplan requirements for UNICEF Open Source Mentorship programme. These requirements apply to companies in the Bridge Fund cohort.
+tags: []
+
+---
+// document settings
+:hide-uri-scheme:
+// reference links
+:unicef-advisor: Justin W. Flory
+:unicef-advisor-email: jflory [at] unicef [dot] org
+
+This page documents the workplan requirements for the Bridge Fund cohort of the UNICEF Innovation Fund.
+These graduation expectations are in place for UNICEF grantees receiving follow-on funding from UNICEF.
+See the table of contents for navigating.
+
+//TODO fix hugo theme to correctly render toc attributes instead of hand-typing them out
+// https://github.com/unicef/inventory/issues/29
+//:toc:
+. link:#mission[Mission]
+. link:#vision[Vision]
+. link:#community[Community]
+. link:#timeline[Timeline]
+.. link:#timeline-q1[Q1]
+.. link:#timeline-q2[Q2]
+.. link:#timeline-q3[Q3]
+.. link:#timeline-q4[Q4]
+. link:#references[References]
+
+
+[[mission]]
+== Mission
+
+*Bridging humanitarian Open Source works and communities to the wider Open Source ecosystem.*
+
+
+[[vision]]
+== Vision
+
+*To support innovative Open Source solutions in their path to becoming https://en.wikipedia.org/wiki/Digital_public_goods[Digital Public Goods].*
+
+
+[[community]]
+== Community
+
+The UNICEF Bridge Funding cohort is more than just a portfolio of software.
+The cohort represents cutting-edge innovations and a community of contributors from around the world, who work with each other to advance the interests of children.
+Unlike most Venture Capital incubators, we invite the world to participate with our projects too.
+A key benefit of the Work Open, Lead Open model is the accelerated feedback cycle by opening up Bridge Funding projects with the wider community.
+We are software engineers, designers and artists, system administrators, web designers, writers, speakers, translators, and more.
+
+We believe that all contributors should be excellent to each other.
+By creating an environment for constructive contribution, we can more effectively and successfully compare and challenge different ideas to find the best solutions for advancement, while building the size, diversity, and strength of our community.
+
+
+[[timeline]]
+== Timeline
+
+[[timeline-q1]]
+=== Q1
+
+==== Activity 1
+
+*Verify graduation requirements are still satisfied since previous round*:
+
+. READMEs in relevant repositories that include how developers can get started developing, prerequisites, and instructions on local configuration/set-up, and details about how the open source community can engage;
+. Deployment Instructions that include how and where the software is hosted;
+. Verification that source code is public and licensed with Free and Open Licenses;
+. If unit test coverage is measured, must be above 80% on average across all tested repositories.
+
+==== Activity 2
+
+If needed:
+*Achieve updated Open Source standards and expectations* for 2021 Innovation Fund graduate companies.
+
+==== Activity 3
+
+*Map key stakeholders and their roles*.
+Create documentation that maps Open Source works to key stakeholders and their method of participation in the community.
+
+==== Activity 4
+
+*Define a project charter*.
+The project charter defines the project, a mission, a vision, and the community.
+
+==== Activity 5
+
+_If a new community_:
+Build a public product roadmap, highlighting the next one month of planned development.
+
+==== Activity 6
+
+_If a new community_:
+Establish a public chat for developers and contributors.
+Add links/info to project charter, READMEs, and other documentation as needed.
+
+==== Activity 7
+
+_If participating in an upstream_:
+Send individual or a team introduction on the upstream's community chat or discussion platform.
+
+==== Activity 8
+
+_If participating in an upstream_:
+Identify key areas of work/contribution in an upstream, and open a discussion in upstream's community discussion platform (e.g. mailing list, forum, issue tracker, etc.).
+
+==== Activity 9
+
+Submit an application to become certified as a Digital Public Good.
+
+[[timeline-q2]]
+=== Q2
+
+==== Activity 1
+
+Open a community discussion with key stakeholders about governance models and decision-making frameworks for the Open Source works.
+
+==== Activity 2
+
+Identify and adopt a governance model. Implement it into day-to-day decision-making and development work.
+
+==== Activity 3
+
+Document governance model in project charter.
+
+==== Activity 4
+
+_If a new community_:
+Create a community publishing channel (e.g. a company blog or mailing list).
+Write one article explaining how the community arrived at the chosen governance model and why.
+
+==== Activity 5
+
+_If participating in an upstream_:
+Explore outreach outlets of the upstream community.
+Check documentation or ask a maintainer how to share new content or add to the upstream's existing outreach efforts.
+
+==== Activity 6
+
+Periodic project charter review.
+
+==== Activity 7
+
+Periodic Digital Public Good review.
+
+==== Activity 8
+
+Adapt workplan as needed to accommodate changing circumstances and community engagement.
+
+[[timeline-q3]]
+=== Q3
+
+==== Activity 1
+
+Develop a targeted Open Source outreach plan.
+Evaluate potential upstreams, related communities, conferences, forums and mailing lists.
+Identify a subset as most relevant for your product.
+
+==== Activity 2
+
+Participate in an external outreach event.
+This means packaging your product and taking it to other relevant Open Source community conferences and events.
+This looks different from team to team;
+seek guidance from Open Source Mentor for more details.
+
+==== Activity 3
+
+Build community mindshare.
+Invite others to participate.
+Invite key stakeholders to be more active participants in project governance.
+Interview community contributors to better understand what they enjoy and what they do not.
+
+==== Activity 4
+
+Periodic project charter review.
+
+==== Activity 5
+
+Periodic Digital Public Good review.
+
+==== Activity 6
+
+Adapt workplan as needed to accommodate changing circumstances and community engagement.
+
+[[timeline-q4]]
+=== Q4
+
+==== Activity 1
+
+Establish 6-18 month objectives.
+Integrate into public product roadmap and project charter.
+
+==== Activity 2
+
+Continue execution of targeted Open Source outreach plan (Q3).
+
+==== Activity 3
+
+Final project charter review.
+
+==== Activity 4
+
+Final Digital Public Good review.
+
+==== Activity 5
+
+Growth planning, contextual analysis, and tailored support with Open Source Mentor.
+
+
+[[references]]
+== References
+
+* https://docs.fedoraproject.org/en-US/project/[Mission and Foundation], _fedoraproject.org_
+* https://www.atlassian.com/work-management/project-management/mission-and-vision[Mission vs. vision statements: definitions & examples], _atlassian.com_


### PR DESCRIPTION
This commit adds the Open Source workplan requirements for the incoming
Bridge Funding cohort to the Open Source Inventory. The current format
is text-heavy and crude, but there is potential to model this into
another feature in the site theme later on.