### PR TITLE
Add code syntax highlighting to code blocks #39

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -145,3 +145,18 @@ title = "UNICEF Open Source Inventory"
 subtitle = "A UNICEF Global Innovation knowledge base of best practices and resources for working and leading Open."
 bg_image = "img/banner.jpg"
 placeholder = "Have a question? Search the site here."
+
+
+[markup]
+[markup.highlight]
+anchorLineNos = false
+codeFences = true
+guessSyntax = false
+hl_Lines = ''
+lineAnchors = ''
+lineNoStart = 1
+lineNos = false
+lineNumbersInTable = true
+noClasses = true
+style = 'murphy'
+tabWidth = 4

--- a/content/meta/maintainers-guide.en.adoc
+++ b/content/meta/maintainers-guide.en.adoc
@@ -75,13 +75,13 @@ The git submodule must be updated from the content repository.
 The shell commands below were tested with the git command line client, version 2.31 or later:
 
 {{< highlight bash "linenos=table,hl_lines=8 15-17,linenostart=1" >}}
-  git submodule update --remote --rebase
-  cd themes/inventory/
-  git fetch
-  git checkout <latest commit hash>
-  cd ../../
-  git add themes/inventory
-  git commit --signoff
+git submodule update --remote --rebase
+cd themes/inventory/
+git fetch
+git checkout <latest commit hash>
+cd ../../
+git add themes/inventory
+git commit --signoff
 {{< / highlight >}}
 
 [[conventions-priorities]]

--- a/content/meta/maintainers-guide.en.adoc
+++ b/content/meta/maintainers-guide.en.adoc
@@ -74,16 +74,15 @@ The git submodule must be updated from the content repository.
 
 The shell commands below were tested with the git command line client, version 2.31 or later:
 
-[source,sh]
-----
-git submodule update --remote --rebase
-cd themes/inventory/
-git fetch
-git checkout <latest commit hash>
-cd ../../
-git add themes/inventory
-git commit --signoff
-----
+{{< highlight bash "linenos=table,hl_lines=8 15-17,linenostart=1" >}}
+  git submodule update --remote --rebase
+  cd themes/inventory/
+  git fetch
+  git checkout <latest commit hash>
+  cd ../../
+  git add themes/inventory
+  git commit --signoff
+{{< / highlight >}}
 
 [[conventions-priorities]]
 === How development decisions are prioritized

--- a/syntax.css
+++ b/syntax.css
@@ -1,0 +1,604 @@
+/* Background */
+
+.chroma {
+    background-color: #ffffff
+}
+
+
+/* Other */
+
+.chroma .x {}
+
+
+/* Error */
+
+.chroma .err {
+    color: #ff0000;
+    background-color: #ffaaaa
+}
+
+
+/* LineTableTD */
+
+.chroma .lntd {
+    vertical-align: top;
+    padding: 0;
+    margin: 0;
+    border: 0;
+}
+
+
+/* LineTable */
+
+.chroma .lntable {
+    border-spacing: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    width: auto;
+    overflow: auto;
+    display: block;
+}
+
+
+/* LineHighlight */
+
+.chroma .hl {
+    display: block;
+    width: 100%;
+    background-color: #ffffcc
+}
+
+
+/* LineNumbersTable */
+
+.chroma .lnt {
+    margin-right: 0.4em;
+    padding: 0 0.4em 0 0.4em;
+    color: #7f7f7f
+}
+
+
+/* LineNumbers */
+
+.chroma .ln {
+    margin-right: 0.4em;
+    padding: 0 0.4em 0 0.4em;
+    color: #7f7f7f
+}
+
+
+/* Keyword */
+
+.chroma .k {
+    color: #228899;
+    font-weight: bold
+}
+
+
+/* KeywordConstant */
+
+.chroma .kc {
+    color: #228899;
+    font-weight: bold
+}
+
+
+/* KeywordDeclaration */
+
+.chroma .kd {
+    color: #228899;
+    font-weight: bold
+}
+
+
+/* KeywordNamespace */
+
+.chroma .kn {
+    color: #228899;
+    font-weight: bold
+}
+
+
+/* KeywordPseudo */
+
+.chroma .kp {
+    color: #0088ff;
+    font-weight: bold
+}
+
+
+/* KeywordReserved */
+
+.chroma .kr {
+    color: #228899;
+    font-weight: bold
+}
+
+
+/* KeywordType */
+
+.chroma .kt {
+    color: #6666ff;
+    font-weight: bold
+}
+
+
+/* Name */
+
+.chroma .n {}
+
+
+/* NameAttribute */
+
+.chroma .na {
+    color: #000077
+}
+
+
+/* NameBuiltin */
+
+.chroma .nb {
+    color: #007722
+}
+
+
+/* NameBuiltinPseudo */
+
+.chroma .bp {}
+
+
+/* NameClass */
+
+.chroma .nc {
+    color: #ee99ee;
+    font-weight: bold
+}
+
+
+/* NameConstant */
+
+.chroma .no {
+    color: #55eedd;
+    font-weight: bold
+}
+
+
+/* NameDecorator */
+
+.chroma .nd {
+    color: #555555;
+    font-weight: bold
+}
+
+
+/* NameEntity */
+
+.chroma .ni {
+    color: #880000
+}
+
+
+/* NameException */
+
+.chroma .ne {
+    color: #ff0000;
+    font-weight: bold
+}
+
+
+/* NameFunction */
+
+.chroma .nf {
+    color: #55eedd;
+    font-weight: bold
+}
+
+
+/* NameFunctionMagic */
+
+.chroma .fm {}
+
+
+/* NameLabel */
+
+.chroma .nl {
+    color: #997700;
+    font-weight: bold
+}
+
+
+/* NameNamespace */
+
+.chroma .nn {
+    color: #0e84b5;
+    font-weight: bold
+}
+
+
+/* NameOther */
+
+.chroma .nx {}
+
+
+/* NameProperty */
+
+.chroma .py {}
+
+
+/* NameTag */
+
+.chroma .nt {
+    color: #007700
+}
+
+
+/* NameVariable */
+
+.chroma .nv {
+    color: #003366
+}
+
+
+/* NameVariableClass */
+
+.chroma .vc {
+    color: #ccccff
+}
+
+
+/* NameVariableGlobal */
+
+.chroma .vg {
+    color: #ff8844
+}
+
+
+/* NameVariableInstance */
+
+.chroma .vi {
+    color: #aaaaff
+}
+
+
+/* NameVariableMagic */
+
+.chroma .vm {}
+
+
+/* Literal */
+
+.chroma .l {}
+
+
+/* LiteralDate */
+
+.chroma .ld {}
+
+
+/* LiteralString */
+
+.chroma .s {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringAffix */
+
+.chroma .sa {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringBacktick */
+
+.chroma .sb {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringChar */
+
+.chroma .sc {
+    color: #8888ff;
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringDelimiter */
+
+.chroma .dl {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringDoc */
+
+.chroma .sd {
+    color: #dd4422;
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringDouble */
+
+.chroma .s2 {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringEscape */
+
+.chroma .se {
+    color: #666666;
+    background-color: #e0e0ff;
+    font-weight: bold
+}
+
+
+/* LiteralStringHeredoc */
+
+.chroma .sh {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringInterpol */
+
+.chroma .si {
+    background-color: #eeeeee
+}
+
+
+/* LiteralStringOther */
+
+.chroma .sx {
+    color: #ff8888;
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringRegex */
+
+.chroma .sr {
+    color: #000000;
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringSingle */
+
+.chroma .s1 {
+    background-color: #e0e0ff
+}
+
+
+/* LiteralStringSymbol */
+
+.chroma .ss {
+    color: #ffcc88;
+    background-color: #e0e0ff
+}
+
+
+/* LiteralNumber */
+
+.chroma .m {
+    color: #6600ee;
+    font-weight: bold
+}
+
+
+/* LiteralNumberBin */
+
+.chroma .mb {
+    color: #6600ee;
+    font-weight: bold
+}
+
+
+/* LiteralNumberFloat */
+
+.chroma .mf {
+    color: #6600ee;
+    font-weight: bold
+}
+
+
+/* LiteralNumberHex */
+
+.chroma .mh {
+    color: #005588;
+    font-weight: bold
+}
+
+
+/* LiteralNumberInteger */
+
+.chroma .mi {
+    color: #6666ff;
+    font-weight: bold
+}
+
+
+/* LiteralNumberIntegerLong */
+
+.chroma .il {
+    color: #6600ee;
+    font-weight: bold
+}
+
+
+/* LiteralNumberOct */
+
+.chroma .mo {
+    color: #4400ee;
+    font-weight: bold
+}
+
+
+/* Operator */
+
+.chroma .o {
+    color: #333333
+}
+
+
+/* OperatorWord */
+
+.chroma .ow {
+    color: #000000;
+    font-weight: bold
+}
+
+
+/* Punctuation */
+
+.chroma .p {}
+
+
+/* Comment */
+
+.chroma .c {
+    color: #666666;
+    font-style: italic
+}
+
+
+/* CommentHashbang */
+
+.chroma .ch {
+    color: #666666;
+    font-style: italic
+}
+
+
+/* CommentMultiline */
+
+.chroma .cm {
+    color: #666666;
+    font-style: italic
+}
+
+
+/* CommentSingle */
+
+.chroma .c1 {
+    color: #666666;
+    font-style: italic
+}
+
+
+/* CommentSpecial */
+
+.chroma .cs {
+    color: #cc0000;
+    font-weight: bold;
+    font-style: italic
+}
+
+
+/* CommentPreproc */
+
+.chroma .cp {
+    color: #557799
+}
+
+
+/* CommentPreprocFile */
+
+.chroma .cpf {
+    color: #557799
+}
+
+
+/* Generic */
+
+.chroma .g {}
+
+
+/* GenericDeleted */
+
+.chroma .gd {
+    color: #a00000
+}
+
+
+/* GenericEmph */
+
+.chroma .ge {
+    font-style: italic
+}
+
+
+/* GenericError */
+
+.chroma .gr {
+    color: #ff0000
+}
+
+
+/* GenericHeading */
+
+.chroma .gh {
+    color: #000080;
+    font-weight: bold
+}
+
+
+/* GenericInserted */
+
+.chroma .gi {
+    color: #00a000
+}
+
+
+/* GenericOutput */
+
+.chroma .go {
+    color: #888888
+}
+
+
+/* GenericPrompt */
+
+.chroma .gp {
+    color: #c65d09;
+    font-weight: bold
+}
+
+
+/* GenericStrong */
+
+.chroma .gs {
+    font-weight: bold
+}
+
+
+/* GenericSubheading */
+
+.chroma .gu {
+    color: #800080;
+    font-weight: bold
+}
+
+
+/* GenericTraceback */
+
+.chroma .gt {
+    color: #0044dd
+}
+
+
+/* GenericUnderline */
+
+.chroma .gl {
+    text-decoration: underline
+}
+
+
+/* TextWhitespace */
+
+.chroma .w {
+    color: #bbbbbb
+}


### PR DESCRIPTION
In order to see results, follow this syntax making sure you state the name of the language immediately after the `highlight` opening shortcode. This example uses the Go programming language. In between the opening and closing `highlight` shortcode is where the actual code will reside.
```
{{< highlight go "linenos=table,hl_lines=8 15-17,linenostart=199" >}}
// ... code
{{< / highlight >}}
```