### PR TITLE
meta: Document how to create Inventory categories

### DIFF
--- a/content/meta/create-new-category.en.adoc
+++ b/content/meta/create-new-category.en.adoc
@@ -1,0 +1,43 @@
+---
+title: "How to create a new Inventory category"
+weight: 10
+description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
+tags: ["docs", "legal", "testing"]
+categories: "meta"
+
+---
+:toc:
+
+This how-to article explains how to create a new category in the Open Source Inventory.
+
+
+[#steps]
+== Steps
+
+. Create a new folder in the `content/` directory.
+. Create a `_index.en.adoc` page in the new directory (see link:#template[template]).
+. Add the category to `config.yml` as a child to `++[[menu.main]]++`.
+  See other categories in the config as an example.
+
+
+[#template]
+== Template for new index pages
+
+Use this base template for the front-matter of a new index page:
+
+{{< highlight yaml "linenos=table,hl_lines=8 15-17,linenostart=1" >}}
+---
+title: "Pretty name"
+icon: "ti-layout-width-default-alt"
+description: "Subtitle to describe your category."
+type: "docs"
+
+---
+{{< / highlight >}}
+
+
+[#template--choose-icon]
+=== Choose an icon
+
+The icon used in the index file comes from the https://themify.me/themify-icons[Themify Icons] set.
+The name of an icon must match the name of an icon appearing on this list.

--- a/content/meta/maintainers-guide.en.adoc
+++ b/content/meta/maintainers-guide.en.adoc
@@ -1,6 +1,6 @@
 ---
 title: "Maintainer's guide for O.S. Inventory"
-weight: 10
+weight: 20
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "testing"]
 

--- a/content/meta/modules.en.adoc
+++ b/content/meta/modules.en.adoc
@@ -1,6 +1,6 @@
 ---
 title: "Modules"
-weight: 10
+weight: 30
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "legal", "testing"]
 categories: "meta"


### PR DESCRIPTION
This commit adds a new how-to page that describes how to add a new
category to the Open Source Inventory. This came up while I was working
on Pull Request #52 when I forgot the link to the icon set… so better to
document it for next time.