### PR TITLE
Add asciidoc config for automatic TOC

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,7 +146,7 @@ name = "@UNICEFinnovate on Twitter"
 link = "https://twitter.com/UNICEFinnovate"
 
 
-############################# Highlight syntax for code blocks #############################
+############################# Markup tweaks and customization #############################
 [markup]
 [markup.highlight]
 anchorLineNos = false
@@ -162,17 +162,8 @@ style = 'murphy'
 tabWidth = 4
 
 [markup.asciidocExt]
-backend = 'html5'
-extensions = []
-failureLevel = 'fatal'
-noHeaderOrFooter = true
 preserveTOC = true
-safeMode = 'unsafe'
-sectionNumbers = false
-trace = false
-verbose = false
-workingFolderCurrent = false
-[markup.asciidocExt.attributes]
+sectionNumbers = true
 
 ############################# Related Articles #############################
 [taxonomies]

--- a/config.toml
+++ b/config.toml
@@ -161,6 +161,19 @@ noClasses = true
 style = 'murphy'
 tabWidth = 4
 
+[markup.asciidocExt]
+backend = 'html5'
+extensions = []
+failureLevel = 'fatal'
+noHeaderOrFooter = true
+preserveTOC = true
+safeMode = 'unsafe'
+sectionNumbers = false
+trace = false
+verbose = false
+workingFolderCurrent = false
+[markup.asciidocExt.attributes]
+
 ############################# Related Articles #############################
 [taxonomies]
   category = "categories"

--- a/content/dev-tools/continuous-integration.en.adoc
+++ b/content/dev-tools/continuous-integration.en.adoc
@@ -6,20 +6,10 @@ tags: ["testing"]
 categories: "dev-tools"
 
 ---
+:toc:
 
 This guide is an introduction to Continuous Integration (C.I.) for Open Source projects.
 In this guide, you will learn about the following topics:
-
-//:toc:
-
-[arabic]
-. link:#what-why[What is CI and why does it matter?]
-.. link:#tests-vs-ci[Tests vs. CI]
-.. link:#benefits[Benefits]
-. link:#platforms[CI platforms]
-. link:#tips[Tips and tricks]
-. link:#examples[Examples]
-. link:#resources[Other resources]
 
 
 [[what-why]]

--- a/content/governance/governance.en.adoc
+++ b/content/governance/governance.en.adoc
@@ -8,14 +8,13 @@ aliases:
     - /foss/governance/
 
 ---
+:toc:
 
 This page defines and provides examples of Open Source governance.
 This includes Open Source project governance models, examples of other projects, frameworks for decision-making, and more.
 
 This page is a work-in-progress.
 Check back later for future additions.
-
-:toc:
 
 
 [[about]]

--- a/content/hardware/intro.en.adoc
+++ b/content/hardware/intro.en.adoc
@@ -7,25 +7,12 @@ categories: "hardware"
 
 ---
 :definition: https://www.oshwa.org/definition/
+:toc:
 
 So… you want to know about Open Source Hardware?
 This page is an introduction to what Open Source Hardware means, how it works, and why it matters.
 Other pages in this Open Source Heuristic category will expand your understanding of Open Source Hardware;
 however, if you need a place to begin, this is a good start!
-
-See the following sections below:
-
-:toc:
-
-. link:#overview[What is Open Source Hardware?]
-.. link:#overview-takeaway[Takeaway]
-. link:#examples[Where does Open Source Hardware exist today?]
-. link:#benefits[Why Open Source Hardware is a win for your project]
-.. link:#benefits-reproducibility[Reason no. 1: Reproducibility]
-.. link:#benefits-community[Reason no. 2: Community participation]
-.. link:#benefits-trademark[Reason no. 3: Trademark protections]
-. link:#oshwa[Open Source Hardware Association]
-. link:#resources[Resources and other references]
 
 
 [[overview]]

--- a/content/legal-policy/contributor-license-agreement-cla.en.adoc
+++ b/content/legal-policy/contributor-license-agreement-cla.en.adoc
@@ -8,6 +8,7 @@ aliases:
     - /foss/contributor-license-agreement-cla/
 
 ---
+:author: Mike Nolan; Justin W. Flory
 :toc:
 
 _Originally authored by https://nolski.rocks[Mike Nolan], edited and maintained by https://jwf.io[Justin W. Flory]._

--- a/content/legal-policy/gpl-comparison.en.adoc
+++ b/content/legal-policy/gpl-comparison.en.adoc
@@ -8,12 +8,12 @@ aliases:
     - /foss/gpl-comparison/
 
 ---
+:toc:
+
 *The information shared on this page does not constitute legal or financial advice*.
 
 This page provides an interpretation of the key differences between v2 and v3 of the GNU Public License, or G.P.L.
 The key differences are summarized in each section below.
-
-:toc:
 
 
 [[tivoization]]

--- a/content/meta/create-new-category.en.adoc
+++ b/content/meta/create-new-category.en.adoc
@@ -25,7 +25,7 @@ This how-to article explains how to create a new category in the Open Source Inv
 
 Use this base template for the front-matter of a new index page:
 
-{{< highlight yaml "linenos=table,hl_lines=8 15-17,linenostart=1" >}}
+{{< highlight yaml "linenos=table,hl_lines=8 15-17" >}}
 ---
 title: "Pretty name"
 icon: "ti-layout-width-default-alt"

--- a/content/meta/maintainers-guide.en.adoc
+++ b/content/meta/maintainers-guide.en.adoc
@@ -7,7 +7,6 @@ tags: ["docs", "testing"]
 ---
 // document settings
 :toc:
-:hide-uri-scheme:
 
 This document is a maintainer's guide for the UNICEF Open Source Inventory.
 Yes, this very site!

--- a/content/meta/modules.en.adoc
+++ b/content/meta/modules.en.adoc
@@ -8,23 +8,9 @@ categories: "meta"
 ---
 // document settings
 :toc:
-:hide-uri-scheme:
 
 The UNICEF Open Source Mentorship programme offers multiple learning modules and mentorship topics.
 This page provides an overview of the different modules currently offered through the Open Source Mentorship programme.
-
-. link:#offered[Offered modules]
-.. link:#offered-legal[Legal & Licensing: Foundations of Open Source intellectual property]
-.. link:#offered-launching[Launching your Open Source project]
-.. link:#offered-docs[Open Source documentation]
-.. link:#offered-ci[Continuous Integration for continuous contribution]
-.. link:#offered-archetypes[Archetypes: Shape and size of Open Source over time]
-. link:#program[Module programming]
-.. link:#program-12mo[12-month Innovation Fund contracts]
-... link:#program-12mo-q1[Q1]
-... link:#program-12mo-q2[Q2]
-... link:#program-12mo-q3[Q3]
-... link:#program-12mo-q4[Q4]
 
 
 [[offered]]

--- a/content/meta/workplan-bridge-funding.en.adoc
+++ b/content/meta/workplan-bridge-funding.en.adoc
@@ -8,6 +8,7 @@ categories: "meta"
 ---
 // document settings
 :hide-uri-scheme:
+:toc:
 // reference links
 :unicef-advisor: Justin W. Flory
 :unicef-advisor-email: jflory [at] unicef [dot] org
@@ -15,19 +16,6 @@ categories: "meta"
 This page documents the workplan requirements for the Bridge Fund cohort of the UNICEF Innovation Fund.
 These graduation expectations are in place for UNICEF grantees receiving follow-on funding from UNICEF.
 See the table of contents for navigating.
-
-//TODO fix hugo theme to correctly render toc attributes instead of hand-typing them out
-// https://github.com/unicef/inventory/issues/29
-//:toc:
-. link:#mission[Mission]
-. link:#vision[Vision]
-. link:#community[Community]
-. link:#timeline[Timeline]
-.. link:#timeline-q1[Q1]
-.. link:#timeline-q2[Q2]
-.. link:#timeline-q3[Q3]
-.. link:#timeline-q4[Q4]
-. link:#references[References]
 
 
 [[mission]]

--- a/content/missions/codes-of-conduct.en.adoc
+++ b/content/missions/codes-of-conduct.en.adoc
@@ -6,7 +6,7 @@ tags: ["community"]
 categories: "missions"
 
 ---
-:page-authors: Justin W. Flory
+:author: Justin W. Flory
 :toc:
 
 [link=https://creativecommons.org/licenses/by-sa/4.0/]

--- a/content/project-management/project-boards.en.adoc
+++ b/content/project-management/project-boards.en.adoc
@@ -6,20 +6,12 @@ tags: ["community"]
 categories: "project-management"
 
 ---
+:toc:
 
 This guide is an introduction to *project boards* for your open source project.
 By the end of this guide, you will have a basic understanding of how to run project planning in an open, transparent way to your community.
 What this guide is _NOT_ is a guide to agile/scrum development.
 You should have a basic understanding of agile, scrum, and/or kanban before reading this article.
-
-The following topics are covered:
-
-:toc:
-
-. About project boards
-. Case study: TeleIRC
-. Examples
-. Additional resources
 
 
 == About project boards


### PR DESCRIPTION
This fixes issue #29. By default hugo turns off the asciidoc automatic TOC since it has its own TOC.
Setting preserveTOC to 'true' instead of 'false' turns on asciidoc's TOC.

Signed-off-by: Ida Delphine <mida@unicef.org>