### PR TITLE
ci: Fix builds with a repo-specific deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ jobs:
     environment:
       HUGO_BUILD_DIR: ~/hugo/inventory/public
     steps:
+      # add repository deploy key (for pull/push access)
+      - add_ssh_keys:
+          fingerprints:
+            - "vJfw0s71s8lL1EQDXH/UPqaV7nZD3z6Uq8NiQDAuZbw"
+
       # deploy.sh dependencies
       - run: apk add rsync
 


### PR DESCRIPTION
This commit fixes the CircleCI pipeline by using a read-write deploy key
for checking out changes from the unicef/inventory repository, and
subsequently pushing the changes back into the `gh-pages` branch when
the `deploy` job successfully completes.

This is necessary because I had previously used a user key tied to my
individual GitHub account, and this key was reset when I reauthenticated
my CircleCI account to GitHub while debugging an unrelated issue with
CircleCI support. This approach, while less intuitive, is more
sustainable so that the deploy key is not bound to my personal GitHub
account.

https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-deploy-key