### PR TITLE
missions: Create a template for writing new Missions

### DIFF
--- a/content/meta/create-new-mission.en.adoc
+++ b/content/meta/create-new-mission.en.adoc
@@ -1,0 +1,43 @@
+---
+title: "How to create a new Inventory Mission"
+weight: 14
+description: Guidance on creating a new Mission in the Open Source Inventory.
+tags: ["content"]
+categories: "meta"
+
+---
+:toc:
+
+This how-to article explains how to create a new category in the Open Source Inventory.
+This how-to article explains how to create a new link:++{{< ref "missions" >}}>++[Mission] in the Open Source Inventory.
+
+
+[#steps]
+== Steps
+
+. Copy the Mission template as a new file using the file committed at `content/meta/_template.en.adoc`.
+. Edit the template front-matter to include a `weight`, `description`, `tags`, and `categories`
+  (see descriptions below).
+. Edit the content using the questions in the template as structural guidelines.
+. Remove `draft: true` from the front-matter.
+. Publish changes and submit a Pull Request.
+
+
+[[front-matter]]
+== Front-matter data values
+
+All Missions (and all content on the site) should specify the following required metadata:
+
+[source,yaml]
+----
+title: Build a rocketship <1>
+weight: 10 <2>
+description: Embark on a new mission to build your first rocketship to Mars. <3>
+tags: ["design", "hardware", "teamwork"] <4>
+categories: "missions" <5>
+----
+<1> `title` is a noun in plural form. It clearly defines what the Mission topic is.
+<2> `weight` is set to maintain alphabetical sort order on all Missions. Check other Missions first to find the right value.
+<3> `description` is one, at most two, sentences to describe the Mission topic.
+<4> `tags` is a descriptive list of words to describe key elements of the Mission. Check other Missions to see tags already in use.
+<5> `categories` is a single value and must always be set to `missions` for a new Mission.

--- a/content/missions/_template.en.adoc
+++ b/content/missions/_template.en.adoc
@@ -1,0 +1,55 @@
+---
+title: "Template for new missions"
+draft: true
+weight: 1
+
+---
+:author: Justin W. Flory
+:toc:
+
+// Use this AsciiDoc template to create a new Mission.
+// Note to change front-matter metadata and document attributes above as needed.
+
+[link=https://creativecommons.org/licenses/by-sa/4.0/]
+image::https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg[License: CC BY-SA 4.0]
+
+This Mission is a guide to … .
+A … is important in an Open Source context because … .
+This Mission unpacks what goes into creating good … and why it is important.
+
+
+[[checklist]]
+== Launch checklist
+
+_What do you need to be successful to "launch" your … ?_
+
+// This section provides context into what the reader needs to take account of before beginning this Mission.
+// Consider who and what will be needed in order to "take off".
+// Anything described here is considered "mission critical" for the work to be worthwhile.
+
+
+[[preparing]]
+== Preparing for take-off
+
+// This section provides context into pre-work or pre-planning to engage in before taking on the primary task.
+// Consider stakeholders, feedback to collect, brainstorming time, or any other "thinking ahead" type exercises.
+// Anything described here should be described in concrete terms, as specific actions one can take.
+
+
+[[launch]]
+== Take-off! Time to launch
+
+// This section defines the primary task and what goes into accomplishing a successful implementation.
+// Consider work that directly impacts the creation of the final deliverable.
+// Anything described here should be as specific actions directly related to the Mission's title.
+
+
+[[destination]]
+== Destination: …
+
+// NOTE: Edit the header to specify the contextually-relevant "destination" that this Mission brings a project to.
+//
+// This section provides context on why this Mission is important for a healthy Open Source community.
+// Consider both short-term and long-term impacts linked to successfully implementing this Mission.
+// This section concludes the Mission and it is advised to keep it succinct and short.
+// The primary intention of a Mission is instruction, not clarification; clarification belongs as another type of content.


### PR DESCRIPTION
This commit adds a draft page of a template that can be reused for
creating new Missions in the future. It also adds documentation as a new
Meta page to describe writing new Missions for other content authors.

This is contributing work to #51. I realized that Missions were not
written in a common format, and this disrupts the user experience. Using
a common template and documenting it also reduces bus factor to include
other writers in the process.