### PR TITLE
meta: Create new Mentorship sub-section

### DIFF
--- a/content/meta/mentorship/_index.en.adoc
+++ b/content/meta/mentorship/_index.en.adoc
@@ -1,0 +1,10 @@
+---
+title: "Open Source Mentorship"
+description: "Documentation and reference material about the UNICEF Open Source Mentorship programme."
+type: "docs"
+
+---
+
+This sub-section includes documentation about the UNICEF link:++{{< relref "overview" >}}++[Open Source Mentorship programme].
+You can find content specific to logistics and day-to-day management of the programme by UNICEF Office of Innovation mentors.
+Use the sidebar to navigate to different topics.

--- a/content/meta/mentorship/modules.en.adoc
+++ b/content/meta/mentorship/modules.en.adoc
@@ -1,9 +1,11 @@
 ---
 title: "Modules"
-weight: 30
+weight: 10
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "legal", "testing"]
 categories: "meta"
+aliases:
+    - /meta/modules/
 downloadBtn: "true"
 
 ---

--- a/content/meta/mentorship/needs-assessment-template.en.adoc
+++ b/content/meta/mentorship/needs-assessment-template.en.adoc
@@ -1,9 +1,11 @@
 ---
 title: "Needs assessment interview template"
-weight: 50
+weight: 20
 description: Interview template for UNICEF mentors when meeting a team for the first time.
 tags: ["tools"]
 categories: "meta"
+aliases:
+    - /meta/needs-assessment-template/
 downloadBtn: "true"
 
 ---

--- a/content/meta/mentorship/overview.en.adoc
+++ b/content/meta/mentorship/overview.en.adoc
@@ -6,6 +6,7 @@ tags: []
 categories: "meta"
 aliases:
     - /foss/
+    - /meta/overview/
 downloadBtn: "true"
 
 ---

--- a/content/meta/mentorship/templates.en.adoc
+++ b/content/meta/mentorship/templates.en.adoc
@@ -1,9 +1,11 @@
 ---
 title: "Templates for programme mentors"
-weight: 60
+weight: 40
 description: Various templates and reusable copytext for UNICEF Open Source Mentorship programme mentors.
 tags: ["tools"]
 categories: "meta"
+aliases:
+    - /meta/templates/
 downloadBtn: "true"
 
 ---
@@ -20,7 +22,7 @@ I use these for my private notes about each team's progress.
 ** Offer to record call
 ** Review O.S. Terms of Reference
 ** Review frequently-used resources (i.e. UNICEF Open Source Inventory & evaluation rubric)
-** link:++{{< ref "meta/needs-assessment-template" >}}++[Needs assessment] (Q&A)
+** link:++{{< relref "needs-assessment-template" >}}++[Needs assessment] (Q&A)
 ** Open source strategy (12-month vision, 1-month action plan)
 * *Needs assessment*:
 * *Open source strategy*:

--- a/content/meta/mentorship/workplan-bridge-funding.en.adoc
+++ b/content/meta/mentorship/workplan-bridge-funding.en.adoc
@@ -1,9 +1,11 @@
 ---
 title: "Workplan: Bridge Fund cohort"
-weight: 80
+weight: 50
 description: Open Source workplan requirements for UNICEF Open Source Mentorship programme. These requirements apply to companies in the Bridge Fund cohort.
 tags: []
 categories: "meta"
+aliases:
+    - /meta/workplan-bridge-funding/
 downloadBtn: "true"
 
 ---


### PR DESCRIPTION
This commit improves the general overview and layout of the Meta
category to include a new sub-section specifically for the Open Source
Mentorship programme. This makes it easier to group like content
together, and opens up possibility for more sub-categories in the Meta
category in the future.

This commit precedes a change to add a new page about on-boarding for
the Open Source Mentorship programme. ( #36 )