### PR TITLE
meta: Create new Inventory sub-section

### DIFF
--- a/content/meta/inventory/_index.en.adoc
+++ b/content/meta/inventory/_index.en.adoc
@@ -1,0 +1,10 @@
+---
+title: "Open Source Inventory maintenance"
+description: "Documentation and reference material about this website, the Open Source Inventory."
+type: "docs"
+
+---
+
+This sub-section includes documentation about managing and maintaining the Open Source Inventory, i.e. this website.
+You can find content specific to maintaining the site from software and content points-of-view.
+Use the sidebar to navigate to different topics.

--- a/content/meta/inventory/create-new-category.en.adoc
+++ b/content/meta/inventory/create-new-category.en.adoc
@@ -4,6 +4,8 @@ weight: 10
 description: Guidance on creating a new content category in the Open Source Inventory.
 tags: ["admin"]
 categories: "meta"
+aliases:
+    - /meta/create-new-category/
 downloadBtn: "true"
 
 ---

--- a/content/meta/inventory/create-new-mission.en.adoc
+++ b/content/meta/inventory/create-new-mission.en.adoc
@@ -1,9 +1,12 @@
 ---
 title: "How to create a new Inventory Mission"
-weight: 14
+weight: 20
 description: Guidance on creating a new Mission in the Open Source Inventory.
 tags: ["content"]
 categories: "meta"
+aliases:
+    - /meta/create-new-mission/
+downloadBtn: "true"
 
 ---
 :toc:

--- a/content/meta/inventory/maintainers-guide.en.adoc
+++ b/content/meta/inventory/maintainers-guide.en.adoc
@@ -1,8 +1,10 @@
 ---
 title: "Maintainer's guide for O.S. Inventory"
-weight: 20
+weight: 30
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "testing"]
+aliases:
+    - /meta/maintainers-guide/
 downloadBtn: "true"
 
 ---


### PR DESCRIPTION
This commit creates a new sub-section for the Open Source Inventory site
underneath the Meta category. This follows on to the change introduced
in #70 to make it easier to navigate content in this category, as the
amount of content continues to grow.

It also gives us more design context for #61.