### PR TITLE
meta: Add On-boarding guide (closes #36)

### DIFF
--- a/content/meta/mentorship/onboarding.en.adoc
+++ b/content/meta/mentorship/onboarding.en.adoc
@@ -1,0 +1,76 @@
+---
+title: "On-boarding guide for UNICEF Innovation Fund teams"
+weight: 30
+description: Terms of reference for being on-boarded to the UNICEF Open Source Mentorship programme as a start-up.
+tags: [""]
+categories: "meta"
+downloadBtn: "true"
+
+---
+:toc:
+
+This document is for teams newly joining the UNICEF Innovation Fund.
+It provides a high-level overview to the UNICEF Open Source Mentorship programme, a unique perk and strategic asset of being a UNICEF investee.
+
+
+[[summary]]
+== Summary of UNICEF Open Source Mentorship
+
+Your assigned Open Source Mentor from the Innovation Fund can be found on the link:++{{< relref "overview#team" >}}++[programme team list].
+In the next few months, your assigned mentor will work with you to develop your business models with Free and Open Source intellectual property, build an open-first intellectual property strategy, and explore early dynamics of building community around your intellectual property.
+
+There are two formats of mentorship to expect:
+
+. Direct support over audio/video calls
+. Self-serve resources to help you better understand working “open”
+
+In Months 1-6, *CEOs/founders, CTOs, and/or leads of engineering are encouraged to join Open Source Mentorship calls*.
+The first six months focus on business models, understanding intellectual property law and policy, and matching an Open Source license to the business model.
+The first half of the Open Source Mentorship programme debunks stereotypes, and shares honest strengths and weaknesses of working with Open Source software, hardware, data, and content.
+At the end of the six months, the executive leadership team will have a better understanding of how Open Source enables innovation.
+At the latest, you will be working in public repositories by the end of the six months.
+
+In Months 7-12, *engineering leads, project managers, and developers are encouraged to join Open Source Mentorship calls*.
+The second six months focus on implementation details of structuring your Open Source project in a way where it can scale.
+Topics during this time might be an Open Source documentation site, testing and continuous integration pipelines, git pull request workflows, and more.
+At the end of the second six months, the technical team will have a better understanding of how to carry out their work in a way compatible with an Open Source project.
+
+[[summary-monthly]]
+=== Monthly 60m check-ins
+
+Each team is asked to check-in once a month, in a one-hour meeting, with the Open Source Mentor.
+Recurring monthly meetings have the following agenda:
+
+. Recap of previous month’s discussion and action items
+. Team shares verbal/oral update on previous items, collaborations, and partnerships
+. Looking ahead for the next month, connecting back to Open Source Mentorship programme objectives.
+
+_Note_:
+The first meeting with the Open Source Mentor, the Induction Meeting, typically runs 90 minutes.
+
+[[summary-adhoc]]
+=== Ad-hoc 30m meetings
+
+Your team may request a 30-minute ad-hoc meeting with the Open Source Mentor up to two times a month if there is a specific topic to cover beyond scheduled monthly check-ins.
+While monthly calls are typically strategic and high-level, an ad-hoc meeting is a chance to get personalized, direct support on any Open Source topic.
+An ad-hoc meeting typically focuses on one or two clearly-scoped topics.
+
+Contact the Open Source Mentor via email to request a 30-minute ad-hoc meeting.
+When reaching out, please offer a preferred and alternate date/time available to meet.
+
+
+[[inventory]]
+== Meet the Inventory
+
+Additionally, there is a self-serve resource available: the UNICEF Open Source Inventory.
+You are browsing it now!
+
+The Open Source Inventory is a knowledge-base of best practices around creating and working with Open Source works.
+This is an important resource for the Open Source Mentorship and was created based on experiences of previous graduates of the UNICEF Innovation Fund.
+You can also request new topics to be added to the knowledge-base too.
+
+
+[[topics]]
+== Topics covered in Open Source Mentorship
+
+_See link:++{{< relref "modules" >}}++[Modules]._


### PR DESCRIPTION
This commit adds an on-boarding guide, or the Terms of Reference, for
new inductees to the UNICEF Open Source Mentorship programme. It is
adapted from the Terms of Reference document, originally drafted in a
Google Doc. This takes that Terms of Reference document, converts it to
AsciiDoc, and better integrates it into existing Inventory content.

https://docs.google.com/document/d/1U_YnIx7Oe1D5O5sBN9FmI2GaC8D93P972v8jcs63EHQ/edit?usp=sharing

There is more content to add here, but for now, this is a good first
step. The Google Doc will be wiped out and replaced with a link out to
this page once it is published.

Closes #36.