### PR TITLE
:new: :tm: legal-policy: Add trademark strategy overview (closes #49)

### DIFF
--- a/content/legal-policy/trademark.en.adoc
+++ b/content/legal-policy/trademark.en.adoc
@@ -102,16 +102,40 @@ These investments into the Moodle L.M.S. by Blackboard were followed with code c
 [[resources]]
 == Resources
 
-*Trademark rules and guidelines from other Open Source projects*:
+Various resources and information pertaining to trademarks in an open-source context.
 
+[[resources-examples]]
+=== Implementations & examples
+
+Trademark rules and guidelines from other Open Source projects.
+
+* http://www.apache.org/foundation/marks/[Apache Software Foundation trademark policy]
 * https://fedoraproject.org/wiki/Legal:Trademark_guidelines[Fedora Project trademark guidelines]
-* https://www.linuxfoundation.org/trademark-usage[The “Linux®” Trademark]
+* https://www.linuxfoundation.org/trademark-usage/[Linux Foundation trademark usage]
+** https://www.linuxfoundation.org/trademark-usage[The “Linux®” Trademark]
 * https://moodle.com/trademarks/[The Moodle Trademark]
 * https://www.python.org/psf/trademarks/[Python Software Foundation]
 
-*Templates and tools to help you create your own trademark policy*:
+[[resources-readings]]
+=== Related readings
+
+* https://web.archive.org/web/20211104210547/https://www.linuxfoundation.org/blog/driving-compatibility-with-code-and-specifications-through-conformance-trademark-programs/[Driving Compatibility with Code and Specifications through Conformance Trademark Programs].
+  _The Linux Foundation®_, 2020 July 2.
+* https://web.archive.org/web/20210428001205/https://www.linuxfoundation.org/blog/open-source-communities-and-trademarks-a-reprise/[Open Source Communities and Trademarks: A Reprise]
+  _The Linux Foundation®_, 2020 July 8.
+
+[[resources-tools]]
+=== Templates & tools
+
+Templates and tools to help you create your own trademark policy.
 
 * GitHub's Minimum Viable Governance (MVG) https://github.com/github/MVG/blob/main/org-docs/TRADEMARKS.md[template for trademark policy]
 * https://modeltrademarkguidelines.org/index.php/Home:_Model_Trademark_Guidelines[Model Trademark Guidelines Project]:
 ** https://modeltrademarkguidelines.org/index.php/Model_Trademark_Guidelines[Official guidelines]
 ** https://modeltrademarkguidelines.org/index.php/Case_law[Case law]
+
+
+[[thanks]]
+== Thanks
+
+Special thanks to https://aniszczyk.org/[Chris Aniszczyk] for his contribution in this article.

--- a/content/legal-policy/trademark.en.adoc
+++ b/content/legal-policy/trademark.en.adoc
@@ -1,0 +1,117 @@
+---
+title: "Trademark strategies"
+weight: 70
+description: Guidance on developing a strategy for Open Source trademarks and branding.
+tags: ["trademark", "legal"]
+categories: "legal"
+downloadBtn: "true"
+
+---
+:toc:
+
+Launching an Open Source project has many considerations.
+Trademarks are one such consideration and are commonly misunderstood.
+However, trademarks are an important legal aspect of building a sustainable Open Source product and community.
+Being clear on your trademarks and their use provides clarity and guidance for others when they use, change, or modify your Open Source works.
+
+
+[[what]]
+== What are trademarks?
+
+Before crafting a strategy, knowing what constitutes a trademark is important.
+Trademarks can be any of the following:
+
+* Organization name
+* Each of the Organization's projects
+* Any associated names to the organization and/or projects
+* Service marks
+* Logos
+* Mascots
+* Similar indicators of source or origin
+
+In short, a trademark can be anything to distinguish your organization or your project from another.
+The trademark is how others will recognize you, your community, and your work.
+
+
+[[why]]
+== Why trademarks matter in Open Source
+
+Trademarks carry an added weight in an Open Source context.
+When you have an Open Source work, you guarantee that anyone can *read, run, revise, and redistribute* the original work.
+Someone else (or another organization) may choose to modify your original Open Source work into a similar or different work.
+Sometimes this is done to submit upstream contributions back to the original work, and there is little to no need for strong trademark policies.
+Other times, this is done to create a competing solution or product to the original Open Source work.
+
+When an original work is used to create a new work, a clear trademark strategy becomes important.
+The new work may have a different vision from the original work.
+It may or may not try to be associated to the original work.
+If the new work opts to remain closely tied to the original work, a trademark is how the two works will be distinguished from each other.
+From a business model perspective, a clearly distinguished trademark is what allows your customers (and prospective customers) to recognize your work, your services, and your community from others.
+
+While Open Source works are meant to be shared, built upon, and extended by others, a trademark is something unique to the original creators of a work and is not meant to be widely reused or remixed.
+If a trademark is unclear or left ambiguous, it leaves room for a competitor or another project to disrupt the original project by using brand recognition and customer familiarity to shift focus to a new work.
+Even if there is goodwill between an original work and a new work, this can happen unintentionally and create confusion for both works if it is not clarified in advance.
+
+[[why--company-vs-project]]
+=== Separating company and project trademarks: When to do it?
+
+A common question by https://www.unicefinnovationfund.org/[UNICEF Innovation Fund] start-ups is whether their company trademarks should be used for the project trademarks.
+The short answer is, it depends!
+The option to take depends on your business model and how you envision the use of marks related to the project.
+
+Generally it is a best practice to create unique trademarks for the Open Source product.
+This enables clear recognition of the product and/or services related to the product.
+It becomes possible to offer different permutations of the Open Source product by distinguishing the trademark, e.g. an enterprise or targeted version.
+Another approach is to give others permissions to use official trademarks with special conditions.
+
+Sometimes a company can use their same trademarks as a business for the Open Source product.
+This creates a tight coupling of the company/business and the Open Source product.
+This can be advantageous in some cases to more tightly control the marks related to the product with the company (e.g. GitLab Inc. is a https://www.bloomberg.com/profile/company/1295950D:NA[registered corporation] in the Netherlands, but also is the same name of their https://about.gitlab.com/[core offering], GitLab).
+It can be disadvantageous in scenarios where the original Open Source product could be adapted or repurposed in new ways, and those derivative works must use a different mark to distinguish the derivative work from the original upstream work.
+
+
+[[case-study-moodle]]
+== Case study: Business models & Moodle
+
+One example of how business models can impact trademarks is by looking at Moodle, an open-source learning management system (L.M.S.).
+The Moodle L.M.S. is described by the company below:
+
+[quote, moodle.com/lms/]
+____
+Moodle LMS is the open source learning management system with inherent security and privacy features used by hundreds of millions of learners worldwide.
+Designed in collaboration with Moodle’s global community, Moodle LMS allows educators in any sector to create flexible, safe, accessible and highly engaging online spaces for their learners.
+____
+
+The Moodle trademark is governed under specific allowed and restricted uses.
+They offer a partner certification program, where service providers or resellers can obtain certification by Moodle.
+Certification also grants official permission to use the official Moodle trademark in marketing and outreach by the partner company.
+
+Furthermore, Moodle also leveraged its own competitors to buy into the Moodle business model.
+In 2012, the e-learning company Blackboard https://www.insidehighered.com/news/2012/03/27/blackboard-buys-moodlerooms-creates-open-source-division[acquired two companies] that provided support for using Moodle.
+Blackboard also launched an Open Source Services Group internally to go along with these acquisitions, a move that surprised many who were familiar with Blackboard's business strategy pre-2012.
+
+[quote, insidehighered.com]
+____
+“We think it’s a terrific time to be making investments in the leading brands behind providing Moodle services,” [Ray Henderson, president of Blackboard Learn] told Inside Higher Ed on Monday.
+In a https://web.archive.org/web/20160821040117/http://www.rayhblog.com/blog/2012/03/evolution-unbound-blackboard-embraces-open-source.html[blog post], he called the growing popularity of open source “the most important new dimension shaping the LMS market today.”
+____
+
+These investments into the Moodle L.M.S. by Blackboard were followed with code contributions and financial support from Blackboard to Moodle Trust, which funds core development on the Moodle platform.
+
+
+[[resources]]
+== Resources
+
+*Trademark rules and guidelines from other Open Source projects*:
+
+* https://fedoraproject.org/wiki/Legal:Trademark_guidelines[Fedora Project trademark guidelines]
+* https://www.linuxfoundation.org/trademark-usage[The “Linux®” Trademark]
+* https://moodle.com/trademarks/[The Moodle Trademark]
+* https://www.python.org/psf/trademarks/[Python Software Foundation]
+
+*Templates and tools to help you create your own trademark policy*:
+
+* GitHub's Minimum Viable Governance (MVG) https://github.com/github/MVG/blob/main/org-docs/TRADEMARKS.md[template for trademark policy]
+* https://modeltrademarkguidelines.org/index.php/Home:_Model_Trademark_Guidelines[Model Trademark Guidelines Project]:
+** https://modeltrademarkguidelines.org/index.php/Model_Trademark_Guidelines[Official guidelines]
+** https://modeltrademarkguidelines.org/index.php/Case_law[Case law]


### PR DESCRIPTION
This commit adds a new page to the "Legal & Policy" category titled,
"Trademark strategies". It includes an introduction to what trademarks
are, why they matter in an Open Source context, and it gives a specific
case study of the Moodle learning management system as a model for
trademark management and business model integration.

The purpose of this page is to provide guidance and nonbinding advice to
UNICEF Venture Fund companies in defining their own trademarks and
crafting a strategy around the management of project marks. This
compliments other content on defining project charters and governance.

Closes #49.

![Screenshot preview of the full page contents rendered offline.](https://user-images.githubusercontent.com/4721034/139879236-e8d8b25d-82cc-4baf-8df7-30db33c1dd04.png "Screenshot preview of the full page contents rendered offline.")