### PR TITLE
:judge: :telescope: legal-policy: Add Creative Commons primer

### DIFF
--- a/content/legal-policy/creative-commons.en.adoc
+++ b/content/legal-policy/creative-commons.en.adoc
@@ -38,6 +38,7 @@ The UNICEF Venture Fund recognizes the following licenses as acceptable as open 
 * *CC BY-SA 4.0* (https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 International]) (_preferred_)
 * *CC BY-NC 4.0* (https://creativecommons.org/licenses/by-nc/4.0/[Attribution-NonCommercial 4.0 International])
 * *CC BY-NC-SA 4.0* (https://creativecommons.org/licenses/by-nc-sa/4.0/[Attribution-NonCommercial-ShareAlike 4.0 International])
+* *CC0* (https://creativecommons.org/share-your-work/public-domain/cc0/[“No Rights Reserved”], or _Public Domain Dedication_)
 
 
 [[free-culture]]
@@ -48,6 +49,7 @@ Only two Creative Commons license variants are https://freedomdefined.org/Licens
 
 * *CC BY 4.0* (https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International])
 * *CC BY-SA 4.0* (https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 International])
+* *CC0* (https://creativecommons.org/share-your-work/public-domain/cc0/[“No Rights Reserved”], or _Public Domain Dedication_)
 
 These are considered compatible with Free Cultural Works, because they do not restrict any of the essential freedoms.
 There are four essential freedoms defined in the Free Cultural Works definition:

--- a/content/legal-policy/creative-commons.en.adoc
+++ b/content/legal-policy/creative-commons.en.adoc
@@ -1,0 +1,106 @@
+---
+title: "Intro to Creative Commons licenses"
+weight: 25
+description: A crash course on Creative Commons licenses and how they are applied at the UNICEF Venture Fund.
+tags: ["content", "licenses", "legal"]
+categories: "legal"
+downloadBtn: "true"
+
+---
+:toc:
+
+
+[[what]]
+== What are Creative Commons licenses?
+
+The Creative Commons licenses are a https://creativecommons.org/share-your-work/[family of licenses] meant for "open" content.
+The licenses are maintained by the Creative Commons, "a nonprofit organization that helps overcome legal obstacles to the sharing of knowledge and creativity to address the world’s pressing challenges."
+They provide a legal framework for sharing open-source content with different rules and requirements for reuse and distribution.
+Collaboration is accelerated when you have a common legal framework for working with open content.
+Instead of working out complicated legal partner agreements and terms, your content can build off an established family of licenses used by organizations like Wikipedia, YouTube, Vimeo, the Internet Archive, and more.
+
+These licenses enable collaborative processes and communities to form around content.
+The content is more likely to be sustainable if it can fit a governance and sharing model that is compatible with an open commons of information.
+Therefore, the UNICEF Venture Fund recognizes a subset of the Creative Commons licenses as valid open licenses for contractual agreements with the Venture Fund.
+
+This is one way the support model for the Venture Fund enables two-way growth even with zero-equity funding.
+The UNICEF Venture Fund provides early-stage seed funding and mentorship programmes to support start-up companies from UNICEF programme countries build an open strategy for their work.
+The start-up company benefits from the funding and lived experience shared by the Venture Fund.
+UNICEF benefits by furthering our mission for every child to have legally-acceptable content that can be used and reused across the diverse range of areas where UNICEF works, in our https://www.unicef.org/where-we-work[Country Offices] (C.O.s).
+
+
+[[acceptable-licenses]]
+== Acceptable licenses for UNICEF Venture Fund
+
+The UNICEF Venture Fund recognizes the following licenses as acceptable as open licenses for investments:
+
+* *CC BY 4.0* (https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International]) (_preferred_)
+* *CC BY-SA 4.0* (https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 International]) (_preferred_)
+* *CC BY-NC 4.0* (https://creativecommons.org/licenses/by-nc/4.0/[Attribution-NonCommercial 4.0 International])
+* *CC BY-NC-SA 4.0* (https://creativecommons.org/licenses/by-nc-sa/4.0/[Attribution-NonCommercial-ShareAlike 4.0 International])
+
+
+[[free-culture]]
+== Free Cultural Works
+
+The UNICEF Venture Fund prefers licenses compliant with the https://freedomdefined.org/Definition[Free Cultural Works definition].
+Only two Creative Commons license variants are https://freedomdefined.org/Licenses[considered as compatible] with Free Cultural Works:
+
+* *CC BY 4.0* (https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International])
+* *CC BY-SA 4.0* (https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 International])
+
+These are considered compatible with Free Cultural Works, because they do not restrict any of the essential freedoms.
+There are four essential freedoms defined in the Free Cultural Works definition:
+
+[quote, Free Cultural Works definition, freedomdefined.org/Definition]
+____
+* *The freedom to use and perform the work*:
+  The licensee must be allowed to make any use, private or public, of the work.
+  For kinds of works where it is relevant, this freedom should include all derived uses ("related rights") such as performing or interpreting the work.
+  There must be no exception regarding, for example, political or religious considerations.
+* *The freedom to study the work and apply the information*:
+  The licensee must be allowed to examine the work and to use the knowledge gained from the work in any way.
+  The license may not, for example, restrict "reverse engineering".
+* *The freedom to redistribute copies*:
+  Copies may be sold, swapped or given away for free, as part of a larger work, a collection, or independently.
+  There must be no limit on the amount of information that can be copied.
+  There must also not be any limit on who can copy the information or on where the information can be copied.
+* *The freedom to distribute derivative works*:
+  In order to give everyone the ability to improve upon a work, the license must not limit the freedom to distribute a modified version (or, for physical works, a work somehow derived from the original), regardless of the intent and purpose of such modifications.
+  However, some restrictions may be applied to protect these essential freedoms or the attribution of authors.
+____
+
+The following licenses are *not* considered compatible with Free Cultural Works:
+
+* *CC BY-NC 4.0* (https://creativecommons.org/licenses/by-nc/4.0/[Attribution-NonCommercial 4.0 International])
+* *CC BY-NC-SA 4.0* (https://creativecommons.org/licenses/by-nc-sa/4.0/[Attribution-NonCommercial-ShareAlike 4.0 International])
+* *CC BY-ND 4.0* (https://creativecommons.org/licenses/by-nd/4.0/[Attribution-NoDerivatives 4.0 International])
+* *CC BY-NC-ND 4.0* (https://creativecommons.org/licenses/by-nc-nd/4.0/[Attribution-NonCommercial-NoDerivatives 4.0])
+
+Additionally, the "NoDerivatives" license variants are not recognized as open licenses by the UNICEF Venture Fund.
+
+[[free-culture--why]]
+=== Why does UNICEF prefer Free Culture licenses?
+
+The UNICEF Venture Fund prefers licenses compatible with the Free Cultural Works definition because they give us the best assurance to use licensed content in a way that enables us to be innovative and creative in the many contexts and environments where UNICEF works.
+Reusing and improving common content created by others frees up constrained creative resources to solve other pressing challenges towards our mission for every child.
+They also enable opportunities for collaboration and teamwork on building resources and content together, with both internal UNICEF colleagues and external partners.
+
+
+////
+TODO: This is preferably an example of a UNICEF Venture Fund company.
+
+[[case-study-??]]
+== Case study: ??
+////
+
+
+[[resources]]
+== Resources
+
+Various resources and information pertaining to Creative Commons licenses.
+
+* https://creativecommons.org/faq/#does-my-use-violate-the-noncommercial-clause-of-the-licenses[Does my use violate the NonCommercial clause of the licenses?]
+  _Creative Commons FAQ_.
+* https://wiki.creativecommons.org/wiki/NonCommercial_interpretation[NonCommercial interpretation [of Creative Commons licenses\]].
+  _Creative Commons Wiki_.


### PR DESCRIPTION
This commit creates a new page that introduces the Creative Commons
license family in a UNICEF context. It introduces the licenses, explains
the difference between our preferred Free Cultural licenses and other
Creative Commons license variants, and gives the reader clarification on
how to learn more about the licenses.

This can serve as a common, public reference point for the licenses we
permit, and maybe more importantly, why.

![Screenshot preview of a local rendered version of the document.](https://user-images.githubusercontent.com/4721034/141012077-7b3867d4-450f-46bc-a413-4f8d4fbe0aa5.png "Screenshot preview of a local rendered version of the document.")