### PR TITLE
:recycle: :weight_lifting: content: Remove weight front matter

### DIFF
--- a/content/cohorts/blockchain/grassroots.en.adoc
+++ b/content/cohorts/blockchain/grassroots.en.adoc
@@ -5,7 +5,6 @@ description: Prospering economies built by thriving communities.
 tags: ["team"]
 categories: "team"
 type: "profiles"
-weight: 40
 country: "Kenya"
 date: 2021-07-25
 github: "https://github.com/GrassrootsEconomics"

--- a/content/cohorts/blockchain/kotani-pay.en.adoc
+++ b/content/cohorts/blockchain/kotani-pay.en.adoc
@@ -5,7 +5,6 @@ description: Africa's most reliable off-ramps APIs
 tags: ["team"]
 categories: "team"
 type: "profiles"
-weight: 40
 country: "Kenya"
 date: 2021-07-26
 github: "https://github.com/KotaniLabs"

--- a/content/cohorts/blockchain/leaf-global-fintech.en.adoc
+++ b/content/cohorts/blockchain/leaf-global-fintech.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Leaf Global Fintech
-weight: 30
 categories: "team"
 tags: ["team"]
 type: profiles

--- a/content/cohorts/vr-ar/scioxr.en.adoc
+++ b/content/cohorts/vr-ar/scioxr.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: ScioXR
-weight: 50
 categories: "team"
 tags: ["team"]
 type: profiles

--- a/content/communities/fedora.en.adoc
+++ b/content/communities/fedora.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Fedora Project
-weight: 50
 description: The Fedora Project is a community of people working together to build a free and open source operating system.
 tags: ["linux"]
 categories: "communities"

--- a/content/communities/public-lab.en.adoc
+++ b/content/communities/public-lab.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Public Lab
-weight: 100
 description: Public Lab is a community and a non-profit, democratizing science to address environmental issues that affect people.
 tags: ["citizen science", "environment"]
 categories: "communities"

--- a/content/data/milestone-roadmap.en.adoc
+++ b/content/data/milestone-roadmap.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "AI Ethics & Transparency Roadmap - Template"
-weight: 10
 description: How do you document your machine learning development process? This guide shares transparency best practices.
 tags: ["template"]
 categories: "data"

--- a/content/data/model-card.en.adoc
+++ b/content/data/model-card.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Machine Learning Model Card"
-weight: 20
 description: Model cards help you document how your model was made. Use this overview to make your own model cards.
 tags: ["design", "template"]
 categories: "data"

--- a/content/data/traps.en.adoc
+++ b/content/data/traps.en.adoc
@@ -1,12 +1,12 @@
 ---
 title: "Common traps to avoid when building AI systems"
-weight: 30
 description: Assessing common AI/ML mistakes that lead to unintended side effects.
 tags: ["design"]
 categories: "data"
 downloadBtn: "true"
 
 ---
+
 _Assessing common mistakes that lead to unintended side effects._
 Information summarized from https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3265913[_Fairness and Abstraction in Sociotechnical Systems_], a paper published at the 2019 ACM Conference on Fairness, Accountability, and Transparency.
 

--- a/content/design/reading-list.en.adoc
+++ b/content/design/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Design & UX Reading List"
-weight: 10
 description: Various readings and learnings about design in an Open Source context.
 tags: ["reading list"]
 categories: "design"

--- a/content/dev-tools/continuous-integration.en.adoc
+++ b/content/dev-tools/continuous-integration.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Continuous Integration (CI)"
-weight: 10
 description: An introduction to creating a Continuous Integration (CI) pipeline for an Open Source project.
 tags: ["testing"]
 categories: "dev-tools"

--- a/content/documentation/frontier-tech-tips.en.adoc
+++ b/content/documentation/frontier-tech-tips.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Frontier technology tips"
-weight: 10
 description: A summary of Andrew Burden's DevConf 2020 talk about best practices for documenting emerging technology.
 tags: ["innovation"]
 categories: "documentation"

--- a/content/documentation/hall-of-fame.en.adoc
+++ b/content/documentation/hall-of-fame.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Documentation Hall of Fame
-weight: 20
 description: Real examples of Open Source projects with excellent documentation.
 tags: ["hall of fame"]
 categories: "documentation"

--- a/content/documentation/reading-list.en.adoc
+++ b/content/documentation/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Reading list"
-weight: 30
 description: Various readings and learnings about documentation in an Open Source context.
 tags: ["reading list"]
 categories: "documentation"

--- a/content/documentation/text-editors.en.adoc
+++ b/content/documentation/text-editors.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Text editors"
-weight: 50
 description: Educational resources, guides, and information about text editors and IDEs.
 tags: ["tools"]
 categories: "documentation"

--- a/content/governance/governance.en.adoc
+++ b/content/governance/governance.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Governance
-weight: 25
 description: Best practices and examples of governance in real Open Source projects.
 tags: ["policy"]
 categories: "governance"

--- a/content/governance/reading-list.en.adoc
+++ b/content/governance/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Reading list: FOSS"
-weight: 50
 description: Various readings and learnings about Free and Open Source Software.
 tags: ["reading list"]
 categories: "governance"

--- a/content/hardware/case-studies.en.adoc
+++ b/content/hardware/case-studies.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Case studies
-weight: 10
 description: Detailed case studies and analysis of different Open Hardware organizations, projects, and products.
 tags: ["hall of fame"]
 categories: "hardware"

--- a/content/hardware/documentation.en.adoc
+++ b/content/hardware/documentation.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Documentation
-weight: 20
 description: How does documentation work for Open Source Hardware? This page provides a brief introduction.
 tags: ["reading list"]
 categories: "hardware"

--- a/content/hardware/licensing.en.adoc
+++ b/content/hardware/licensing.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Licensing
-weight: 30
 description: Information, resources, and details about common licenses used for Open Source Hardware projects.
 tags: ["legal"]
 categories: "hardware"

--- a/content/hardware/projects.en.adoc
+++ b/content/hardware/projects.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Project Hall of Fame
-weight: 50
 description: Various Open Source Hardware projects and links back to their projects and/or communities.
 tags: ["hall of fame"]
 categories: "hardware"

--- a/content/hardware/reading-list.en.adoc
+++ b/content/hardware/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Open Hardware reading list"
-weight: 40
 description: Various readings and learnings about Open Source Hardware that do not belong on another page.
 tags: ["reading list"]
 categories: "hardware"

--- a/content/legal-policy/contributor-license-agreement-cla.en.adoc
+++ b/content/legal-policy/contributor-license-agreement-cla.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Contributor License Agreements (CLAs)"
-weight: 20
 description: When does your Open Source project need a CLA? What alternatives exist? Cover your copyright in this intro to CLAs.
 tags: ["legal"]
 categories: "legal"

--- a/content/legal-policy/creative-commons.en.adoc
+++ b/content/legal-policy/creative-commons.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Intro to Creative Commons licenses"
-weight: 25
 description: A crash course on Creative Commons licenses and how they are applied at the UNICEF Venture Fund.
 tags: ["content", "licenses", "legal"]
 categories: "legal"

--- a/content/legal-policy/gpl-comparison.en.adoc
+++ b/content/legal-policy/gpl-comparison.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "GPLv2 vs. GPLv3"
-weight: 30
 description: A deep dive on the exact differences between the Free Software Foundation's two versions of the GPL license.
 tags: ["legal"]
 categories: "legal"

--- a/content/legal-policy/reading-list.en.adoc
+++ b/content/legal-policy/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Reading List: Legal & Business Aspects"
-weight: 60
 description: Various readings and learnings about business and legal aspects of Open Source intellectual property.
 tags: ["reading list"]
 categories: "legal"

--- a/content/legal-policy/trademark.en.adoc
+++ b/content/legal-policy/trademark.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Trademark strategies"
-weight: 70
 description: Guidance on developing a strategy for Open Source trademarks and branding.
 tags: ["trademark", "legal"]
 categories: "legal"

--- a/content/meta/inventory/create-new-category.en.adoc
+++ b/content/meta/inventory/create-new-category.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "How to create a new Inventory category"
-weight: 10
 description: Guidance on creating a new content category in the Open Source Inventory.
 tags: ["admin"]
 categories: "meta"

--- a/content/meta/inventory/create-new-mission.en.adoc
+++ b/content/meta/inventory/create-new-mission.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "How to create a new Inventory Mission"
-weight: 20
 description: Guidance on creating a new Mission in the Open Source Inventory.
 tags: ["content"]
 categories: "meta"
@@ -34,13 +33,11 @@ All Missions (and all content on the site) should specify the following required
 [source,yaml]
 ----
 title: Build a rocketship <1>
-weight: 10 <2>
-description: Embark on a new mission to build your first rocketship to Mars. <3>
+description: Embark on a new mission to build your first rocketship to Mars. <2>
+categories: "missions" <3>
 tags: ["design", "hardware", "teamwork"] <4>
-categories: "missions" <5>
 ----
 <1> `title` is a noun in plural form. It clearly defines what the Mission topic is.
-<2> `weight` is set to maintain alphabetical sort order on all Missions. Check other Missions first to find the right value.
-<3> `description` is one, at most two, sentences to describe the Mission topic.
+<2> `description` is one, at most two, sentences to describe the Mission topic.
+<3> `categories` is a single value and must always be set to `missions` for a new Mission.
 <4> `tags` is a descriptive list of words to describe key elements of the Mission. Check other Missions to see tags already in use.
-<5> `categories` is a single value and must always be set to `missions` for a new Mission.

--- a/content/meta/inventory/maintainers-guide.en.adoc
+++ b/content/meta/inventory/maintainers-guide.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Maintainer's guide for O.S. Inventory"
-weight: 30
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "testing"]
 aliases:

--- a/content/meta/mentorship/modules.en.adoc
+++ b/content/meta/mentorship/modules.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Modules"
-weight: 10
 description: Overview of learning modules currently offered through the UNICEF Open Source Mentorship programme.
 tags: ["docs", "legal", "testing"]
 categories: "meta"

--- a/content/meta/mentorship/needs-assessment-template.en.adoc
+++ b/content/meta/mentorship/needs-assessment-template.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Needs assessment interview template"
-weight: 20
 description: Interview template for UNICEF mentors when meeting a team for the first time.
 tags: ["tools"]
 categories: "meta"

--- a/content/meta/mentorship/onboarding.en.adoc
+++ b/content/meta/mentorship/onboarding.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "On-boarding guide for UNICEF Innovation Fund teams"
-weight: 30
 description: Terms of reference for being on-boarded to the UNICEF Open Source Mentorship programme as a start-up.
 tags: [""]
 categories: "meta"

--- a/content/meta/mentorship/templates.en.adoc
+++ b/content/meta/mentorship/templates.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Templates for programme mentors"
-weight: 40
 description: Various templates and reusable copytext for UNICEF Open Source Mentorship programme mentors.
 tags: ["tools"]
 categories: "meta"

--- a/content/meta/mentorship/workplan-bridge-funding.en.adoc
+++ b/content/meta/mentorship/workplan-bridge-funding.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Workplan: Bridge Fund cohort"
-weight: 50
 description: Open Source workplan requirements for UNICEF Open Source Mentorship programme. These requirements apply to companies in the Bridge Fund cohort.
 tags: []
 categories: "meta"

--- a/content/meta/workflow-metrics.en.adoc
+++ b/content/meta/workflow-metrics.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Workflow: Update external UNICEF metrics"
-weight: 70
 description: How a UNICEF contractor manages and updates metrics about Innovation Fund portfolio company projects.
 tags: ["workflows"]
 categories: "meta"

--- a/content/missions/_template.en.adoc
+++ b/content/missions/_template.en.adoc
@@ -1,7 +1,9 @@
 ---
 title: "Template for new missions"
+description: Embark on a mission to create XYZ for your Open Source work.
+categories: "missions"
+downloadBtn: "true"
 draft: true
-weight: 1
 
 ---
 :author: Justin W. Flory

--- a/content/missions/charters.en.adoc
+++ b/content/missions/charters.en.adoc
@@ -1,9 +1,9 @@
 ---
 title: "Charters"
-weight: 10
 description: Embark on a mission to create a project charter for your Open Source work.
 tags: ["documentation"]
 categories: "missions"
+downloadBtn: "true"
 
 ---
 :author: Justin W. Flory

--- a/content/missions/codes-of-conduct.en.adoc
+++ b/content/missions/codes-of-conduct.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Codes of Conduct"
-weight: 20
 description: Embark on a mission to add a Code of Conduct to your Open Source community.
 tags: ["community"]
 categories: "missions"

--- a/content/missions/good-first-issue.en.adoc
+++ b/content/missions/good-first-issue.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Good first issues"
-weight: 30
 description: Embark on a mission to enable new contributors to your Open Source project with Good First Issues (GFIs).
 tags: ["community"]
 categories: "missions"

--- a/content/project-management/issue-templates.en.adoc
+++ b/content/project-management/issue-templates.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Issue templates"
-weight: 10
 description: An introduction to issue templates for new Open Source project or community managers.
 tags: ["community"]
 categories: "project-management"

--- a/content/project-management/project-boards.en.adoc
+++ b/content/project-management/project-boards.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Project boards"
-weight: 20
 description: An introduction to project/kanban boards for new Open Source project or community managers.
 tags: ["community"]
 categories: "project-management"

--- a/content/project-management/reading-list.en.adoc
+++ b/content/project-management/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Outreach reading list"
-weight: 70
 description: Various readings and learnings about outreach and marketing in an Open Source context.
 tags: ["reading list"]
 categories: "project-management"

--- a/content/reproducibility/reading-list.en.adoc
+++ b/content/reproducibility/reading-list.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: "Reproducibility reading list"
-weight: 10
 description: Various readings and learnings about reproducibility in an Open Source context.
 tags: ["reading list"]
 categories: "reproducibility"

--- a/content/sustainability/approaches.en.adoc
+++ b/content/sustainability/approaches.en.adoc
@@ -1,6 +1,5 @@
 ---
 title: Open-first business approaches
-weight: 10
 description: Information, best practices, and references about sustainable Open-first business approaches.
 tags: ["sustainability"]
 categories: "sustainability"


### PR DESCRIPTION
This commit removes the `weight` front matter from all content, except
for posts where it is actually necessary. This allows the existing
content to be sorted by default in alphabetical order, while some
content can be "promoted" to a custom order on an as-needed basis.

The purpose of this commit is reduce unnecessary front matter and make
drafting new content more straightforward. Custom orders can be used in
categories for specific pages when needed, like the Open Hardware intro
and overview of the Open Source Mentorship program.

Props to @Idadelveloper for digging into this one and verifying the
behavior. When I tested this in 2019, the mixed alphabetical and custom
order sort did not work.

Closes unicef/inventory-hugo-theme#14.