### PR TITLE
:lock: config: Add `^asciidoctor$` to new security configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,10 +8,16 @@ enableGitInfo = true
 # Google Analytics
 googleAnalytics = "G-80FMX4TPM0"
 
+
+############################# Security configuration #############################
+
 # Allow unsafe HTML
 [markup.goldmark.renderer]
 unsafe = true
 
+[security]
+    [security.exec]
+        allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$', '^asciidoctor$']
 
 ############################# Navigation #############################
 [[menu.main]]


### PR DESCRIPTION
Beginning from Hugo v0.91.0 and on, security hardening was added to the
Hugo build runtime. This affects how Hugo calls Asciidoctor to generate
HTML from Asciidoc source. Without this setting, `asciidoctor` will fail
to run in Hugo v0.91.0 or later, and cause any pipelines without this
configuration to fail.

More info: https://github.com/gohugoio/hugo/releases/tag/v0.91.0