### PR TITLE
Wrap text description of profile cards around logo

### DIFF
--- a/layouts/partials/cohorts.html
+++ b/layouts/partials/cohorts.html
@@ -110,15 +110,15 @@
             {{ else }}
             <div class="bg-light row pt-3">
             {{range .Pages}}
-                <div class="col-md-6 col-sm-12 card-deck">
-                    <div class="card col mb-3 py-3 border-light" style="background-color: white;">
+                <div class="col-md-6 col-sm-12 card-deck cohort-cards">
+                    <div class="card col mb-3 py-3 border-light relative " style="background-color: white;">
                             <div class="">
-                                <div class="w-50 float-left m-2">
+                                <div class="w-25 float-left m-2">
                                     <img src="{{.Params.logo}}"  alt="{{ .Params.Title }} Logo" srcset="" class="rounded-circle img-fluid">
                                 </div>
                                 
-                                    <h3>{{ .Params.Title }}</h3>
-                                    <p style="font-size: 0.8rem">{{ .Params.Description }}</p>
+                                    <h4>{{ .Params.Title }}</h4>
+                                    <p class="text-left" style="font-size: 0.8rem">{{ .Params.Description }}</p>
                               
                             </div>
                             <div class="row d-flex justify-content-between mx-3 my-2" style="font-size: 0.75rem">

--- a/layouts/partials/cohorts.html
+++ b/layouts/partials/cohorts.html
@@ -112,14 +112,14 @@
             {{range .Pages}}
                 <div class="col-md-6 col-sm-12 card-deck">
                     <div class="card col mb-3 py-3 border-light" style="background-color: white;">
-                            <div class="row">
-                                <div class="col">
+                            <div class="">
+                                <div class="w-50 float-left m-2">
                                     <img src="{{.Params.logo}}"  alt="{{ .Params.Title }} Logo" srcset="" class="rounded-circle img-fluid">
                                 </div>
-                                <div class="col align-items-center">
+                                
                                     <h3>{{ .Params.Title }}</h3>
                                     <p style="font-size: 0.8rem">{{ .Params.Description }}</p>
-                                </div>
+                              
                             </div>
                             <div class="row d-flex justify-content-between mx-3 my-2" style="font-size: 0.75rem">
                                 <span><i class="fa fa-map-marker mr-1"></i>{{ .Params.country }}</span>


### PR DESCRIPTION
@jwflory this addresses #98 

I noticed the cards were overlapping on smaller screens.
![card-issue](https://user-images.githubusercontent.com/56026636/148069790-a41b2a57-0d42-4122-b059-87f47d8182e2.png)

The second commit fixes the issue.
.