### PR TITLE
:memo: :boom: meta: Hide sub-categories from index page

### DIFF
--- a/content/meta/inventory/_index.en.adoc
+++ b/content/meta/inventory/_index.en.adoc
@@ -1,7 +1,6 @@
 ---
 title: "Open Source Inventory maintenance"
 description: "Documentation and reference material about this website, the Open Source Inventory."
-type: "docs"
 
 ---
 

--- a/content/meta/mentorship/_index.en.adoc
+++ b/content/meta/mentorship/_index.en.adoc
@@ -1,7 +1,6 @@
 ---
 title: "Open Source Mentorship"
 description: "Documentation and reference material about the UNICEF Open Source Mentorship programme."
-type: "docs"
 
 ---
 


### PR DESCRIPTION
Closes unicef/inventory-hugo-theme#32.

This commit removes `type: docs` from the sub-category index pages in
the Meta category. This prevents them from appearing in their own card
on the index page view. They still render as expected within the sub-
category.

Nice catch @Idadelveloper.