### PR TITLE
:speech_balloon: :link: cohorts: Add Discord link for Rumsan/Rahat

### DIFF
--- a/content/cohorts/blockchain/rumsan.en.adoc
+++ b/content/cohorts/blockchain/rumsan.en.adoc
@@ -11,7 +11,7 @@ github: https://github.com/esatya
 linkedin: https://www.linkedin.com/company/esatya/
 twitter: https://twitter.com/rahataid
 website: https://rahat.io/
-community: ""
+community: https://discord.gg/c73EXBJyMK
 logo: /inventory/cohorts/logo-rumsan.png
 sdgs:
     - 1


### PR DESCRIPTION
This commit adds the Rumsan/Rahat Discord server to the team profile for
Rumsan. It will appear as a place to engage and ask questions towards
the bottom of the profile.

CC: @rakimsth