### PR TITLE
:alembic: :wrench: ci: Use verbose HTML-Proofer error messages in logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,12 @@
 version: 2.1
 
 orbs:
-  hugo: circleci/hugo@1.2.2
+  hugo: circleci/hugo@1.3.0
 
 workflows:
   main:
     jobs:
       - hugo/build:
-          asciidoc: true
           html-proofer: true
           htmlproofer-http-status-ignore: "'0,999'"
           htmlproofer-url-ignore: "'/inventory/'"


### PR DESCRIPTION
This commit updates the CircleCI Hugo orb to v1.3.0. This change
incorporates changes I made upstream in the Hugo orb so HTML-Proofer
will print verbose error messages if there is a failure. Currently,
error messages are suppressed in the CircleCI logs and this makes
debugging difficult. Additionally, the `asciidoc` binary is now included
in the container image used in this build, so specifying the Asciidoc
parameter in the CircleCI config is no longer necessary.

Related GitHub Pull Requests:

* CircleCI-Public/hugo-orb#47
* CircleCI-Public/hugo-orb#48
* CircleCI-Public/hugo-orb#50