### PR TITLE
:wrench: config: Add Toolkits menu, link out to DS and SD toolkits

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,24 @@ name = "FAQ"
 url = "faq"
 
 [[menu.main]]
+weight = 15
+name = "toolkits"
+url = "toolkits"
+hasChildren = true
+
+    [[menu.main]]
+    parent = "toolkits"
+    name = "Data Science & A.I."
+    url = "https://unicef.github.io/ooi-toolkit-ds/"
+    weight = 10
+
+    [[menu.main]]
+    parent = "toolkits"
+    name = "Software Development"
+    url = "https://unicef.github.io/ooi-toolkit-software/"
+    weight = 20
+
+[[menu.main]]
 weight = 20
 name = "pages"
 url = "pages"


### PR DESCRIPTION
This commit adds a new drop-down menu to the Open Source Inventory. The
_Toolkits_ drop-down includes links to @dalvarez83's Data Science & A.I.
Toolkit and @iperdomo's Software Development Toolkit. This change can be
mirrored to all other toolkit sites as well to improve discoverability.

This should be merged once both sites begin to publish new content.

![Screenshot of the proposed change. A drop-down menu appears on the Open Source Inventory homepage. The drop-down menu shows two options: Data Science and Software Development.](https://user-images.githubusercontent.com/4721034/159521937-24bdbfa1-2264-4a0b-845b-d0719eec517e.png "Screenshot of the proposed change. A drop-down menu appears on the Open Source Inventory homepage. The drop-down menu shows two options: Data Science and Software Development.")