### PR TITLE
:truck: :pencil2: Branding: Change "Innovation Fund" to "Venture Fund"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,6 +4,3 @@ contact_links:
   - name: Open Source Inventory site theme
     url: https://github.com/unicef/inventory-hugo-theme/issues/new/choose
     about: Share feedback, ideas, or report a bug on the site theme used in the Open Source Inventory.
-  - name: UNICEF Innovation Fund Community
-    url: https://unicef-if.discourse.group/
-    about: Please ask and answer questions here.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A UNICEF Global Innovation knowledge base of best practices and resources for wo
 ## About
 
 This repository is a collection of various information about Open Source best practices.
-It was originally created to support [UNICEF Innovation Fund](https://unicefinnovationfund.org/) teams in building Open Source projects and communities.
+It was originally created to support [UNICEF Venture Fund](https://unicefinnovationfund.org/) teams in building Open Source projects and communities.
 The information here can be applied generally to Open Source projects.
 
-This repository also includes an inventory of Innovation Fund companies and their Open Source intellectual property.
+This repository also includes an inventory of Venture Fund companies and their Open Source intellectual property.
 
 
 ## Contributing

--- a/config.toml
+++ b/config.toml
@@ -217,8 +217,8 @@ parent_org_url_legal = "https://www.unicef.org/legal"
 
 [params.footer]
 mainSite = "https://www.unicefinnovationfund.org/"
-mainSiteName = "UNICEF Innovation Fund"
-description = "The UNICEF Open Source Inventory is a knowledge-base of best practices, resources, and information about working and leading Open. This is maintained as part of the Open Source Mentorship programme offered by the UNICEF Innovation Fund. The Inventory provides mentorship and guidance to anyone seeking to adopt best practices in their journey to building an Open Source project and community. It is self-serve, and can be used at various phases of building a project and community."
+mainSiteName = "UNICEF Venture Fund"
+description = "The UNICEF Open Source Inventory is a knowledge-base of best practices, resources, and information about working and leading Open. This is maintained as part of the Open Source Mentorship programme offered by the UNICEF Venture Fund. The Inventory provides mentorship and guidance to anyone seeking to adopt best practices in their journey to building an Open Source project and community. It is self-serve, and can be used at various phases of building a project and community."
 
 
 ############################# Social links #############################

--- a/content/announcements/_index.en.adoc
+++ b/content/announcements/_index.en.adoc
@@ -1,7 +1,7 @@
 ---
 title: "News"
 icon: "ti-comments-smiley"
-description: "Latest news from the UNICEF Innovation Fund team."
+description: "Latest news from the UNICEF Venture Fund team."
 type: "alert"
 
 ---

--- a/content/cohorts/_index.en.adoc
+++ b/content/cohorts/_index.en.adoc
@@ -1,7 +1,7 @@
 ---
 title: "Cohorts"
 icon: "vr-cardboard"
-description: "Explore UNICEF Innovation Fund start-up companies and Open Source projects by cohort."
+description: "Explore UNICEF Venture Fund start-up companies and Open Source projects by cohort."
 type: "team"
 
 ---

--- a/content/cohorts/others/_index.en.adoc
+++ b/content/cohorts/others/_index.en.adoc
@@ -1,7 +1,7 @@
 ---
 title: "Others"
 icon: "shapes"
-description: "Browse other UNICEF Innovation Fund start-ups and Open Source projects from a range of frontier technology areas."
+description: "Browse other UNICEF Venture Fund start-ups and Open Source projects from a range of frontier technology areas."
 type: "profiles"
 
 ---

--- a/content/cohorts/vr-ar/_index.en.adoc
+++ b/content/cohorts/vr-ar/_index.en.adoc
@@ -1,7 +1,7 @@
 ---
 title: "VR + AR"
 icon: "ti-eye"
-description: "The UNICEF Innovation Fund looks for start-ups that are developing and piloting new open source VR/AR solutions."
+description: "The UNICEF Venture Fund looks for start-ups that are developing and piloting new open source VR/AR solutions."
 type: "profiles"
 
 ---

--- a/content/communities/fedora.en.adoc
+++ b/content/communities/fedora.en.adoc
@@ -75,4 +75,4 @@ ____
 Fedora has a team of people to help newcomers get involved with Fedora, known as the https://docs.fedoraproject.org/en-US/fedora-join/[Fedora Join Special Interest Group].
 This is the best way to explore participation in Fedora and see what options there are out there.
 
-If you are a UNICEF Innovation Fund company, reach out to your Open Source Mentor for extra guidance in an Open Source check-in call.
+If you are a UNICEF Venture Fund company, reach out to your Open Source Mentor for extra guidance in an Open Source check-in call.

--- a/content/communities/public-lab.en.adoc
+++ b/content/communities/public-lab.en.adoc
@@ -10,7 +10,7 @@ downloadBtn: "true"
 [link=https://creativecommons.org/licenses/by-sa/4.0/]
 image::https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg[License: CC BY-SA 4.0]
 
-Public Lab is a community of practice that has informally collaborated with UNICEF Innovation Fund team members in the past.
+Public Lab is a community of practice that has informally collaborated with UNICEF Venture Fund team members in the past.
 To learn more about this community, reach out to your assigned Open Source Mentor or see the contact info below.
 
 

--- a/content/legal-policy/trademark.en.adoc
+++ b/content/legal-policy/trademark.en.adoc
@@ -54,7 +54,7 @@ Even if there is goodwill between an original work and a new work, this can happ
 [[why--company-vs-project]]
 === Separating company and project trademarks: When to do it?
 
-A common question by https://www.unicefinnovationfund.org/[UNICEF Innovation Fund] start-ups is whether their company trademarks should be used for the project trademarks.
+A common question by https://www.unicefinnovationfund.org/[UNICEF Venture Fund] start-ups is whether their company trademarks should be used for the project trademarks.
 The short answer is, it depends!
 The option to take depends on your business model and how you envision the use of marks related to the project.
 

--- a/content/meta/inventory/intern-guide.en.adoc
+++ b/content/meta/inventory/intern-guide.en.adoc
@@ -26,7 +26,7 @@ If you are new to Hugo, be sure to take a look at the https://gohugo.io/getting-
 == Introducing the UNICEF Inventory
 
 The link:++{{< ref "/" >}}++[UNICEF Open Source Inventory] is a knowledge base for open source best practices and resources related to open source.
-It also is a key resource used during the link:++{{< ref "/meta/mentorship/overview" >}}++[open source mentorship program] of the various https://www.unicefinnovationfund.org/[UNICEF Innovation Fund] cohorts.
+It also is a key resource used during the link:++{{< ref "/meta/mentorship/overview" >}}++[open source mentorship program] of the various https://www.unicefinnovationfund.org/[UNICEF Venture Fund] cohorts.
 It is built on Hugo and made up of two repositories: the https://github.com/unicef/inventory[*Open Source Inventory*] and the https://github.com/unicef/inventory-hugo-theme[*UNICEF Inventory theme*].
 The Open Source Inventory is mostly for adding content to the site, while the UNICEF Inventory theme is actually the front-end interface of the site.
 The Open Source Inventory also contains global configurations of the Hugo site and also contains the UNICEF Inventory theme as a git submodule.

--- a/content/meta/inventory/maintainers-guide.en.adoc
+++ b/content/meta/inventory/maintainers-guide.en.adoc
@@ -91,7 +91,7 @@ git commit --signoff
 Development decisions are prioritized according to the needs of the following stakeholders:
 
 . UNICEF Office of Innovation staff and consultants
-. UNICEF Innovation Fund grantees and portfolio companies
+. UNICEF Venture Fund grantees and portfolio companies
 . UNICEF colleagues
 . UN colleagues
 . Open Source practitioners and subject-matter experts (e.g. associated to a private-sector Open Source Program Office)

--- a/content/meta/mentorship/modules.en.adoc
+++ b/content/meta/mentorship/modules.en.adoc
@@ -165,10 +165,10 @@ The above modules are typically offered in groups with other modules.
 The programmes and most common combination of modules are described below:
 
 [[program-12mo]]
-=== 12-month Innovation Fund contracts
+=== 12-month Venture Fund contracts
 
 12 months is the standard length of the Open Source Mentorship programme.
-12-month contracts are typically offered through the procurement process through the UNICEF Innovation Fund.
+12-month contracts are typically offered through the procurement process through the UNICEF Venture Fund.
 The breakdown below orders the modules and adds context to what content is covered.
 
 [[program-12mo-q1]]
@@ -228,7 +228,7 @@ This quarter focuses on building strong entrypoints for new contributors to ente
 * Add ticket/issue templates to source code repositories for new tickets opened by the public and the core contributor team.
 * Create "Good First Issues" for bite-sized, low-commitment contributions for new developers to make to your source code repositories.
 * Establish a public communication platform for the public to interact with project development team.
-  (Suggested: UNICEF Innovation Fund community forum.)
+  (Suggested: UNICEF Venture Fund community forum.)
 * Add either developer or user documentation to the Open Source documentation site, whichever was not completed the previous quarter.
 
 [[program-12mo-q4]]

--- a/content/meta/mentorship/needs-assessment-template.en.adoc
+++ b/content/meta/mentorship/needs-assessment-template.en.adoc
@@ -9,7 +9,7 @@ downloadBtn: "true"
 
 ---
 
-This document is an interview template for needs assessments with https://unicefinnovationfund.org/[UNICEF Innovation Fund] cohorts in Open Source induction calls.
+This document is an interview template for needs assessments with https://unicefinnovationfund.org/[UNICEF Venture Fund] cohorts in Open Source induction calls.
 The needs assessment is a tool to collect background and context for each team's experience and familiarity with open source.
 It also builds understanding for participation in existing open source communities.
 This template provides structure and guidance on what to ask to any team at the beginning of an Open Source Mentorship program.

--- a/content/meta/mentorship/onboarding.en.adoc
+++ b/content/meta/mentorship/onboarding.en.adoc
@@ -1,5 +1,5 @@
 ---
-title: "On-boarding guide for UNICEF Innovation Fund teams"
+title: "On-boarding guide for UNICEF Venture Fund teams"
 description: Terms of reference for being on-boarded to the UNICEF Open Source Mentorship programme as a start-up.
 tags: [""]
 categories: "meta"
@@ -8,14 +8,14 @@ downloadBtn: "true"
 ---
 :toc:
 
-This document is for teams newly joining the UNICEF Innovation Fund.
+This document is for teams newly joining the UNICEF Venture Fund.
 It provides a high-level overview to the UNICEF Open Source Mentorship programme, a unique perk and strategic asset of being a UNICEF investee.
 
 
 [[summary]]
 == Summary of UNICEF Open Source Mentorship
 
-Your assigned Open Source Mentor from the Innovation Fund can be found on the link:++{{< relref "overview#team" >}}++[programme team list].
+Your assigned Open Source Mentor from the Venture Fund can be found on the link:++{{< relref "overview#team" >}}++[programme team list].
 In the next few months, your assigned mentor will work with you to develop your business models with Free and Open Source intellectual property, build an open-first intellectual property strategy, and explore early dynamics of building community around your intellectual property.
 
 There are two formats of mentorship to expect:
@@ -65,7 +65,7 @@ Additionally, there is a self-serve resource available: the UNICEF Open Source I
 You are browsing it now!
 
 The Open Source Inventory is a knowledge-base of best practices around creating and working with Open Source works.
-This is an important resource for the Open Source Mentorship and was created based on experiences of previous graduates of the UNICEF Innovation Fund.
+This is an important resource for the Open Source Mentorship and was created based on experiences of previous graduates of the UNICEF Venture Fund.
 You can also request new topics to be added to the knowledge-base too.
 
 

--- a/content/meta/mentorship/overview.en.adoc
+++ b/content/meta/mentorship/overview.en.adoc
@@ -15,7 +15,7 @@ downloadBtn: "true"
 // reference links
 :unicef-advisor: Justin W. Flory
 :unicef-advisor-email: jflory [at] unicef [dot] org
-:unicef-fund: https://www.unicefinnovationfund.org/[UNICEF Innovation Fund,window=read-later]
+:unicef-fund: https://www.unicefinnovationfund.org/[UNICEF Venture Fund,window=read-later]
 :unicef-colleague-support-timeframe: within 1-2 weeks
 
 This page documents and explains the general structure, approach, and methods of the Open Source Mentorship programme hosted on this website.
@@ -25,7 +25,7 @@ See the table of contents for navigating.
 //TODO fix hugo theme to correctly render toc attributes instead of hand-typing them out
 . link:#team[Programme team]
 . link:#eligibility[Eligibility]
-.. link:#eligibility-fund[Innovation Fund grantees]
+.. link:#eligibility-fund[Venture Fund grantees]
 .. link:#eligibility-unicef[UNICEF colleagues]
 .. link:#eligibility-others[Other groups]
 . link:#refs[References]
@@ -34,7 +34,7 @@ See the table of contents for navigating.
 [[team]]
 == Programme team
 
-The Open Source Mentorship programme is administered by the Innovation Fund _Open Source Technical Advisor_.
+The Open Source Mentorship programme is administered by the Venture Fund _Open Source Technical Advisor_.
 Currently, this is {unicef-advisor} <{unicef-advisor-email}>.
 
 Any mentor who is an active 3-month or longer engagement may be listed here as well.
@@ -47,11 +47,11 @@ The guided Open Source Mentorship programme is a 12-month incubator to help a sm
 Eligibility for this hands-on, interactive mentorship is a closed invitation for the groups below:
 
 [[eligibility-fund]]
-=== Innovation Fund grantees
+=== Venture Fund grantees
 
-*Innovation Fund grantees are eligible to enroll in the Open Source Mentorship programme for the duration of their workplans.*
+*Venture Fund grantees are eligible to enroll in the Open Source Mentorship programme for the duration of their workplans.*
 
-Innovation Fund grantees learn about the Open Source Mentorship programme in their on-boarding webinars with the Innovation Fund.
+Venture Fund grantees learn about the Open Source Mentorship programme in their on-boarding webinars with the Venture Fund.
 Their assigned Open Source mentor will reach out with more information after on-boarding about enrollment.
 
 [[eligibility-unicef]]

--- a/content/meta/mentorship/workplan-bridge-funding.en.adoc
+++ b/content/meta/mentorship/workplan-bridge-funding.en.adoc
@@ -15,7 +15,7 @@ downloadBtn: "true"
 :unicef-advisor: Justin W. Flory
 :unicef-advisor-email: jflory [at] unicef [dot] org
 
-This page documents the workplan requirements for the Bridge Fund cohort of the UNICEF Innovation Fund.
+This page documents the workplan requirements for the Bridge Fund cohort of the UNICEF Venture Fund.
 These graduation expectations are in place for UNICEF grantees receiving follow-on funding from UNICEF.
 See the table of contents for navigating.
 
@@ -63,7 +63,7 @@ By creating an environment for constructive contribution, we can more effectivel
 ==== Activity 2
 
 If needed:
-*Achieve updated Open Source standards and expectations* for 2021 Innovation Fund graduate companies.
+*Achieve updated Open Source standards and expectations* for 2021 Venture Fund graduate companies.
 
 ==== Activity 3
 

--- a/content/meta/workflow-metrics.en.adoc
+++ b/content/meta/workflow-metrics.en.adoc
@@ -1,13 +1,13 @@
 ---
 title: "Workflow: Update external UNICEF metrics"
-description: How a UNICEF contractor manages and updates metrics about Innovation Fund portfolio company projects.
+description: How a UNICEF contractor manages and updates metrics about Venture Fund portfolio company projects.
 tags: ["workflows"]
 categories: "meta"
 downloadBtn: "true"
 
 ---
 
-Open Source data and analytics are used across multiple tools and documents for talking about Innovation Fund portfolio companies.
+Open Source data and analytics are used across multiple tools and documents for talking about Venture Fund portfolio companies.
 When updating data sources in official UNICEF portals, follow this process for the quickest way of updating metrics.
 
 . Open data input source (e.g. Sharepoint doc, Google Doc shared with company, etc.)

--- a/layouts/partials/types.html
+++ b/layouts/partials/types.html
@@ -6,7 +6,7 @@
         {{ partial "sidebar.html" . }}
       </div>
       <div class="col-lg-9">
-        
+
         <div>
           <div class="bg-white" style="margin:auto">
             {{ partial "breadcrumb.html" . }}
@@ -16,9 +16,9 @@
             {{ if .Content }}
             {{ else }}
               <div class="bg-light p-4">
-                <p>UNICEF’s Innovation Fund invests in early stage, open-source, emerging technology digital public goods with the potential to impact children on a global scale. It also provides product and technology assistance, support with business growth, access to a network of experts and partners to allow for scale and growth.</p>
+                <p>UNICEF’s Venture Fund invests in early stage, open-source, emerging technology digital public goods with the potential to impact children on a global scale. It also provides product and technology assistance, support with business growth, access to a network of experts and partners to allow for scale and growth.</p>
                 <div class="">
-                    
+
                     <div class="row">
                         {{ range .Pages }}
                         <div class="col-sm-6 mb-5 card-deck">
@@ -34,7 +34,7 @@
                     </div>
                 </div>
             {{ end }}
-            
+
 
           </div>
         </div>


### PR DESCRIPTION
This follows guidance shared by Mara Navarro on branding best practices
for the Venture Fund. We standardize our name as Venture Fund given the
new possibility of other funding modalities that may emerge in the
coming future.