### PR TITLE
:memo: cohorts: Add Facebook and Instagram to OTTAA Project profile

### DIFF
--- a/content/cohorts/ds-ai/ottaa-project.en.adoc
+++ b/content/cohorts/ds-ai/ottaa-project.en.adoc
@@ -9,8 +9,10 @@ description: An Alternative Augmentative Communication (AAC) system, intended fo
 country: Chile
 date: 2020-09-25
 github: https://github.com/OTTAA-Project
-linkedin: https://www.linkedin.com/company/ottaa-project/
+facebook: https://www.facebook.com/ottaaproject/
 twitter: https://twitter.com/OTTAAProject
+instagram: https://www.instagram.com/OTTAAProject/
+linkedin: https://www.linkedin.com/company/ottaa-project/
 website: https://www.ottaaproject.com/
 community: ""
 logo: /inventory/cohorts/logo-ottaa-project.png


### PR DESCRIPTION
This commit adds the Facebook and Instagram information for the OTTAA
Project into the team profile they have on the Open Source Inventory
website. This also updates the theme submodule to the latest commit that
incorporates the new social media platforms.

Related to unicef/inventory-hugo-theme#130.

![Local screenshot of the OTTAA Project team profile with the Facebook and Instagram platforms added.](https://user-images.githubusercontent.com/4721034/185266307-20060da8-8afe-461a-9add-493caaa5ccb2.png "Local screenshot of the OTTAA Project team profile with the Facebook and Instagram platforms added.")