### PR TITLE
:memo: index: Add site description to site index page

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,0 +1,11 @@
+Welcome to the UNICEF Open Source Inventory.
+This is a UNICEF Mentor Toolkit about best practices, resources, and information about working and leading Open.
+This is maintained as part of the [Open Source Mentorship programme]({{< ref "mentoring/overview" >}}) offered by the [UNICEF Venture Fund](https://www.unicefinnovationfund.org/).
+The Inventory provides mentorship and guidance to anyone seeking to adopt best practices in their journey to building an Open Source project and community.
+It is self-serve, and can be used at various phases of building a project and community.
+
+The site content is organized into categories, shown below.
+You can also search for specific content using the search bar on the home page (e.g. `licenses`).
+Most learning resources are in the [_DPG Standard indicators_]({{< ref "dpg-indicators" >}}) category.
+These learning resources are structured around the [Digital Public Goods Standard](https://digitalpublicgoods.net/standard/).
+The Digital Public Goods Alliance provides more information [about digital public goods](https://digitalpublicgoods.net/digital-public-goods/) on their website.


### PR DESCRIPTION
This commit creates an `_index.en.md` file in the `content/` directory, therefore giving the UNICEF Open Source Inventory an explainer text in-between the search bar and the content category boxes.

Closes unicef/inventory-hugo-theme#154.